### PR TITLE
refactor: Re-use client in consumer

### DIFF
--- a/hook-consumer/src/config.rs
+++ b/hook-consumer/src/config.rs
@@ -21,7 +21,7 @@ pub struct Config {
     pub request_timeout: EnvMsDuration,
 
     #[envconfig(default = "1024")]
-    pub max_requests: usize,
+    pub max_concurrent_jobs: usize,
 
     #[envconfig(nested = true)]
     pub retry_policy: RetryPolicyConfig,

--- a/hook-consumer/src/config.rs
+++ b/hook-consumer/src/config.rs
@@ -20,6 +20,9 @@ pub struct Config {
     #[envconfig(default = "5000")]
     pub request_timeout: EnvMsDuration,
 
+    #[envconfig(default = "1024")]
+    pub max_requests: usize,
+
     #[envconfig(nested = true)]
     pub retry_policy: RetryPolicyConfig,
 

--- a/hook-consumer/src/consumer.rs
+++ b/hook-consumer/src/consumer.rs
@@ -204,7 +204,7 @@ impl<'p> WebhookConsumer<'p> {
             tokio::spawn(async move {
                 let result = process_webhook_job(client, webhook_job).await;
                 drop(permit);
-                result.expect("webhook processing failed");
+                result
             });
         }
     }

--- a/hook-consumer/src/consumer.rs
+++ b/hook-consumer/src/consumer.rs
@@ -195,7 +195,6 @@ impl<'p> WebhookConsumer<'p> {
         let semaphore = Arc::new(sync::Semaphore::new(self.max_concurrent_jobs));
 
         loop {
-            // TODO: The number of jobs processed will be capped by the PG connection limit when running in transactional mode.
             let webhook_job = self.wait_for_job().await?;
 
             // reqwest::Client internally wraps with Arc, so this allocation is cheap.

--- a/hook-consumer/src/error.rs
+++ b/hook-consumer/src/error.rs
@@ -1,0 +1,30 @@
+use std::time;
+
+use hook_common::pgqueue;
+use thiserror::Error;
+
+/// Enumeration of errors for operations with WebhookConsumer.
+#[derive(Error, Debug)]
+pub enum WebhookConsumerError {
+    #[error("timed out while waiting for jobs to be available")]
+    TimeoutError,
+    #[error("{0} is not a valid HttpMethod")]
+    ParseHttpMethodError(String),
+    #[error("error parsing webhook headers")]
+    ParseHeadersError(http::Error),
+    #[error("error parsing webhook url")]
+    ParseUrlError(url::ParseError),
+    #[error("an error occurred in the underlying queue")]
+    QueueError(#[from] pgqueue::PgQueueError),
+    #[error("an error occurred in the underlying job")]
+    PgJobError(String),
+    #[error("an error occurred when attempting to send a request")]
+    RequestError(#[from] reqwest::Error),
+    #[error("a webhook could not be delivered but it could be retried later: {reason}")]
+    RetryableWebhookError {
+        reason: String,
+        retry_after: Option<time::Duration>,
+    },
+    #[error("a webhook could not be delivered and it cannot be retried further: {0}")]
+    NonRetryableWebhookError(String),
+}

--- a/hook-consumer/src/lib.rs
+++ b/hook-consumer/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod config;
 pub mod consumer;
+pub mod error;

--- a/hook-consumer/src/main.rs
+++ b/hook-consumer/src/main.rs
@@ -3,9 +3,10 @@ use envconfig::Envconfig;
 use hook_common::pgqueue::{PgQueue, RetryPolicy};
 use hook_consumer::config::Config;
 use hook_consumer::consumer::WebhookConsumer;
+use hook_consumer::error::WebhookConsumerError;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), WebhookConsumerError> {
     let config = Config::init_from_env().expect("Invalid configuration:");
 
     let retry_policy = RetryPolicy::new(
@@ -27,7 +28,9 @@ async fn main() {
         &queue,
         config.poll_interval.0,
         config.request_timeout.0,
-    );
+    )?;
 
     let _ = consumer.run().await;
+
+    Ok(())
 }

--- a/hook-consumer/src/main.rs
+++ b/hook-consumer/src/main.rs
@@ -28,6 +28,7 @@ async fn main() -> Result<(), WebhookConsumerError> {
         &queue,
         config.poll_interval.0,
         config.request_timeout.0,
+        config.max_requests,
     )?;
 
     let _ = consumer.run().await;

--- a/hook-consumer/src/main.rs
+++ b/hook-consumer/src/main.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), WebhookConsumerError> {
         &queue,
         config.poll_interval.0,
         config.request_timeout.0,
-        config.max_requests,
+        config.max_concurrent_jobs,
     )?;
 
     let _ = consumer.run().await;


### PR DESCRIPTION
Follow-up to #3.

This PR implements re-using the `reqwest::Client` spawned in consumer instead of creating a new one for every request. This allows us to:
* Overall, be more efficient.
* Set timeout once for all requests.
* Set headers once for all requests.

This PR also applies a limit to the maximum number of concurrent tasks using a Semaphore. Set to 1024 as default. Follows this pattern: https://docs.rs/tokio/latest/tokio/sync/struct.Semaphore.html#limit-the-number-of-incoming-requests-being-handled-at-the-same-time

Other changes:
* Moved `WebhookConsumerError` to its own module.