### PR TITLE
feat: Support for non transactional consumer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,7 @@ dependencies = [
 name = "hook-common"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "chrono",
  "http 0.2.11",

--- a/hook-common/Cargo.toml
+++ b/hook-common/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = { workspace = true }
 axum = { workspace = true, features = ["http2"] }
 chrono = { workspace = true }
 http = { workspace = true }

--- a/hook-consumer/src/config.rs
+++ b/hook-consumer/src/config.rs
@@ -26,6 +26,9 @@ pub struct Config {
     #[envconfig(nested = true)]
     pub retry_policy: RetryPolicyConfig,
 
+    #[envconfig(default = "true")]
+    pub transactional: bool,
+
     #[envconfig(default = "job_queue")]
     pub table_name: String,
 }

--- a/hook-consumer/src/consumer.rs
+++ b/hook-consumer/src/consumer.rs
@@ -13,28 +13,28 @@ use tokio::sync;
 
 use crate::error::{ConsumerError, WebhookError};
 
-/// A WebhookJob is any PgQueueJob that returns webhook required parameters and metadata.
+/// A WebhookJob is any PgQueueJob that returns a reference to webhook parameters and metadata.
 trait WebhookJob: PgQueueJob + std::marker::Send {
-    fn parameters<'a>(&'a self) -> &'a WebhookJobParameters;
-    fn metadata<'a>(&'a self) -> &'a WebhookJobMetadata;
+    fn parameters(&self) -> &WebhookJobParameters;
+    fn metadata(&self) -> &WebhookJobMetadata;
 }
 
 impl WebhookJob for PgTransactionJob<'_, WebhookJobParameters, WebhookJobMetadata> {
-    fn parameters<'a>(&'a self) -> &'a WebhookJobParameters {
+    fn parameters(&self) -> &WebhookJobParameters {
         &self.job.parameters
     }
 
-    fn metadata<'a>(&'a self) -> &'a WebhookJobMetadata {
+    fn metadata(&self) -> &WebhookJobMetadata {
         &self.job.metadata
     }
 }
 
 impl WebhookJob for PgJob<WebhookJobParameters, WebhookJobMetadata> {
-    fn parameters<'a>(&'a self) -> &'a WebhookJobParameters {
+    fn parameters(&self) -> &WebhookJobParameters {
         &self.job.parameters
     }
 
-    fn metadata<'a>(&'a self) -> &'a WebhookJobMetadata {
+    fn metadata(&self) -> &WebhookJobMetadata {
         &self.job.metadata
     }
 }

--- a/hook-consumer/src/consumer.rs
+++ b/hook-consumer/src/consumer.rs
@@ -23,8 +23,6 @@ pub struct WebhookConsumer<'p> {
     client: reqwest::Client,
     /// Maximum number of concurrent jobs being processed.
     max_concurrent_jobs: usize,
-    /// Indicates whether we are holding an open transaction while processing or not.
-    transactional: bool,
 }
 
 impl<'p> WebhookConsumer<'p> {
@@ -57,16 +55,76 @@ impl<'p> WebhookConsumer<'p> {
     }
 
     /// Wait until a job becomes available in our queue.
-    async fn wait_for_job_tx<'a>(
-        &self,
-    ) -> Result<PgTransactionJob<'a, WebhookJobParameters>, WebhookConsumerError> {
+    async fn wait_for_job<'a>(&self) -> Result<PgJob<WebhookJobParameters>, WebhookConsumerError> {
         loop {
-            if let Some(job) = self.queue.dequeue_tx(&self.name).await? {
+            if let Some(job) = self.queue.dequeue(&self.name).await? {
                 return Ok(job);
             } else {
                 task::sleep(self.poll_interval).await;
             }
         }
+    }
+
+    /// Run this consumer to continuously process any jobs that become available.
+    pub async fn run(&self) -> Result<(), WebhookConsumerError> {
+        let semaphore = Arc::new(sync::Semaphore::new(self.max_concurrent_jobs));
+
+        loop {
+            let webhook_job = self.wait_for_job().await?;
+
+            // reqwest::Client internally wraps with Arc, so this allocation is cheap.
+            let client = self.client.clone();
+            let permit = semaphore.clone().acquire_owned().await.unwrap();
+
+            tokio::spawn(async move {
+                let result = process_webhook_job(client, webhook_job).await;
+                drop(permit);
+                result
+            });
+        }
+    }
+}
+
+/// A consumer to poll `PgQueue` and spawn tasks to process webhooks when a job becomes available.
+pub struct WebhookTransactionConsumer<'p> {
+    /// An identifier for this consumer. Used to mark jobs we have consumed.
+    name: String,
+    /// The queue we will be dequeuing jobs from.
+    queue: &'p PgQueue,
+    /// The interval for polling the queue.
+    poll_interval: time::Duration,
+    /// The client used for HTTP requests.
+    client: reqwest::Client,
+    /// Maximum number of concurrent jobs being processed.
+    max_concurrent_jobs: usize,
+}
+
+impl<'p> WebhookTransactionConsumer<'p> {
+    pub fn new(
+        name: &str,
+        queue: &'p PgQueue,
+        poll_interval: time::Duration,
+        request_timeout: time::Duration,
+        max_concurrent_jobs: usize,
+    ) -> Result<Self, WebhookConsumerError> {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(request_timeout)
+            .build()?;
+
+        Ok(Self {
+            name: name.to_owned(),
+            queue,
+            poll_interval,
+            client,
+            max_concurrent_jobs,
+        })
     }
 
     /// Wait until a job becomes available in our queue.
@@ -87,17 +145,14 @@ impl<'p> WebhookConsumer<'p> {
         let semaphore = Arc::new(sync::Semaphore::new(self.max_concurrent_jobs));
 
         loop {
-            let webhook_job = match self.transactional {
-                true => self.wait_for_job_tx().await,
-                false => self.wait_for_job().await,
-            }?;
+            let webhook_job = self.wait_for_job().await?;
 
             // reqwest::Client internally wraps with Arc, so this allocation is cheap.
             let client = self.client.clone();
             let permit = semaphore.clone().acquire_owned().await.unwrap();
 
             tokio::spawn(async move {
-                let result = process_webhook_job(client, webhook_job).await;
+                let result = process_webhook_job_tx(client, webhook_job).await;
                 drop(permit);
                 result
             });
@@ -182,6 +237,66 @@ async fn process_webhook_job(
                 .fail(WebhookJobError::from(&error))
                 .await
                 .map_err(|job_error| ConsumerError::PgJobError(job_error.to_string()))?;
+            Ok(())
+        }
+    }
+}
+
+/// Process a webhook job by transitioning it to its appropriate state after its request is sent.
+/// After we finish, the webhook job will be set as completed (if the request was successful), retryable (if the request
+/// was unsuccessful but we can still attempt a retry), or failed (if the request was unsuccessful and no more retries
+/// may be attempted).
+///
+/// A webhook job is considered retryable after a failing request if:
+/// 1. The job has attempts remaining (i.e. hasn't reached `max_attempts`), and...
+/// 2. The status code indicates retrying at a later point could resolve the issue. This means: 429 and any 5XX.
+///
+/// # Arguments
+///
+/// * `webhook_job`: The webhook job to process as dequeued from `hook_common::pgqueue::PgQueue`.
+/// * `request_timeout`: A timeout for the HTTP request.
+async fn process_webhook_job(
+    client: reqwest::Client,
+    webhook_job: PgJob<WebhookJobParameters>,
+) -> Result<(), WebhookConsumerError> {
+    match send_webhook(
+        client,
+        &webhook_job.job.parameters.method,
+        &webhook_job.job.parameters.url,
+        &webhook_job.job.parameters.headers,
+        webhook_job.job.parameters.body.clone(),
+    )
+    .await
+    {
+        Ok(_) => {
+            webhook_job
+                .complete()
+                .await
+                .map_err(|error| WebhookConsumerError::PgJobError(error.to_string()))?;
+            Ok(())
+        }
+        Err(WebhookConsumerError::RetryableWebhookError {
+            reason,
+            retry_after,
+        }) => match webhook_job.retry(reason.to_string(), retry_after).await {
+            Ok(_) => Ok(()),
+            Err(PgJobError::RetryInvalidError {
+                job: webhook_job,
+                error: fail_error,
+            }) => {
+                webhook_job
+                    .fail(fail_error.to_string())
+                    .await
+                    .map_err(|job_error| WebhookConsumerError::PgJobError(job_error.to_string()))?;
+                Ok(())
+            }
+            Err(job_error) => Err(WebhookConsumerError::PgJobError(job_error.to_string())),
+        },
+        Err(error) => {
+            webhook_job
+                .fail(error.to_string())
+                .await
+                .map_err(|job_error| WebhookConsumerError::PgJobError(job_error.to_string()))?;
             Ok(())
         }
     }

--- a/hook-consumer/src/main.rs
+++ b/hook-consumer/src/main.rs
@@ -31,7 +31,11 @@ async fn main() -> Result<(), ConsumerError> {
         config.max_concurrent_jobs,
     );
 
-    let _ = consumer.run().await;
+    if config.transactional {
+        consumer.run_tx().await?;
+    } else {
+        consumer.run().await?;
+    }
 
     Ok(())
 }

--- a/hook-consumer/src/main.rs
+++ b/hook-consumer/src/main.rs
@@ -31,11 +31,7 @@ async fn main() -> Result<(), ConsumerError> {
         config.max_concurrent_jobs,
     );
 
-    if config.transactional {
-        consumer.run_tx().await?;
-    } else {
-        consumer.run().await?;
-    }
+    consumer.run(config.transactional).await?;
 
     Ok(())
 }


### PR DESCRIPTION
We do not yet want to commit to either transactional or non transactional running modes, so this makes them configurable in the consumer side. There is perhaps some opportunity for abstraction with traits, but if we commit for one of the two options early enough we could end up dropping the other code.