### PR TITLE
refactor: PgQueue no longer takes a RetryPolicy

### DIFF
--- a/hook-common/src/lib.rs
+++ b/hook-common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod kafka_messages;
 pub mod metrics;
 pub mod pgqueue;
+pub mod retry;
 pub mod webhook;

--- a/hook-common/src/pgqueue.rs
+++ b/hook-common/src/pgqueue.rs
@@ -160,7 +160,7 @@ pub trait PgQueueJob {
     async fn retry<E: serde::Serialize + std::marker::Sync + std::marker::Send>(
         mut self,
         error: E,
-        preferred_retry_interval: Option<time::Duration>,
+        retry_interval: time::Duration,
     ) -> Result<RetryableJob<E>, PgJobError<Box<Self>>>;
 }
 
@@ -247,7 +247,7 @@ RETURNING
     async fn retry<E: serde::Serialize + std::marker::Sync + std::marker::Send>(
         mut self,
         error: E,
-        preferred_retry_interval: Option<time::Duration>,
+        retry_interval: time::Duration,
     ) -> Result<RetryableJob<E>, PgJobError<Box<PgJob<J, M>>>> {
         if self.job.is_gte_max_attempts() {
             return Err(PgJobError::RetryInvalidError {
@@ -392,7 +392,7 @@ RETURNING
     async fn retry<E: serde::Serialize + std::marker::Sync + std::marker::Send>(
         mut self,
         error: E,
-        preferred_retry_interval: Option<time::Duration>,
+        retry_interval: time::Duration,
     ) -> Result<RetryableJob<E>, PgJobError<Box<PgTransactionJob<'c, J, M>>>> {
         if self.job.is_gte_max_attempts() {
             return Err(PgJobError::RetryInvalidError {

--- a/hook-common/src/retry.rs
+++ b/hook-common/src/retry.rs
@@ -4,11 +4,11 @@ use std::time;
 /// The retry policy that PgQueue will use to determine how to set scheduled_at when enqueuing a retry.
 pub struct RetryPolicy {
     /// Coefficient to multiply initial_interval with for every past attempt.
-    backoff_coefficient: u32,
+    pub backoff_coefficient: u32,
     /// The backoff interval for the first retry.
-    initial_interval: time::Duration,
+    pub initial_interval: time::Duration,
     /// The maximum possible backoff between retries.
-    maximum_interval: Option<time::Duration>,
+    pub maximum_interval: Option<time::Duration>,
 }
 
 impl RetryPolicy {

--- a/hook-common/src/retry.rs
+++ b/hook-common/src/retry.rs
@@ -1,0 +1,55 @@
+use std::time;
+
+#[derive(Copy, Clone, Debug)]
+/// The retry policy that PgQueue will use to determine how to set scheduled_at when enqueuing a retry.
+pub struct RetryPolicy {
+    /// Coefficient to multiply initial_interval with for every past attempt.
+    backoff_coefficient: u32,
+    /// The backoff interval for the first retry.
+    initial_interval: time::Duration,
+    /// The maximum possible backoff between retries.
+    maximum_interval: Option<time::Duration>,
+}
+
+impl RetryPolicy {
+    pub fn new(
+        backoff_coefficient: u32,
+        initial_interval: time::Duration,
+        maximum_interval: Option<time::Duration>,
+    ) -> Self {
+        Self {
+            backoff_coefficient,
+            initial_interval,
+            maximum_interval,
+        }
+    }
+
+    /// Calculate the time until the next retry for a given RetryableJob.
+    pub fn time_until_next_retry(
+        &self,
+        attempt: u32,
+        preferred_retry_interval: Option<time::Duration>,
+    ) -> time::Duration {
+        let candidate_interval = self.initial_interval * self.backoff_coefficient.pow(attempt);
+
+        match (preferred_retry_interval, self.maximum_interval) {
+            (Some(duration), Some(max_interval)) => std::cmp::min(
+                std::cmp::max(std::cmp::min(candidate_interval, max_interval), duration),
+                max_interval,
+            ),
+            (Some(duration), None) => std::cmp::max(candidate_interval, duration),
+            (None, Some(max_interval)) => std::cmp::min(candidate_interval, max_interval),
+            (None, None) => candidate_interval,
+        }
+    }
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            backoff_coefficient: 2,
+            initial_interval: time::Duration::from_secs(1),
+            maximum_interval: None,
+        }
+    }
+}

--- a/hook-consumer/src/consumer.rs
+++ b/hook-consumer/src/consumer.rs
@@ -51,8 +51,6 @@ pub struct WebhookConsumer<'p> {
     client: reqwest::Client,
     /// Maximum number of concurrent jobs being processed.
     max_concurrent_jobs: usize,
-    /// Indicates whether we are holding an open transaction while processing or not.
-    transactional: bool,
 }
 
 impl<'p> WebhookConsumer<'p> {
@@ -85,16 +83,76 @@ impl<'p> WebhookConsumer<'p> {
     }
 
     /// Wait until a job becomes available in our queue.
-    async fn wait_for_job_tx<'a>(
-        &self,
-    ) -> Result<PgTransactionJob<'a, WebhookJobParameters>, WebhookConsumerError> {
+    async fn wait_for_job<'a>(&self) -> Result<PgJob<WebhookJobParameters>, WebhookConsumerError> {
         loop {
-            if let Some(job) = self.queue.dequeue_tx(&self.name).await? {
+            if let Some(job) = self.queue.dequeue(&self.name).await? {
                 return Ok(job);
             } else {
                 task::sleep(self.poll_interval).await;
             }
         }
+    }
+
+    /// Run this consumer to continuously process any jobs that become available.
+    pub async fn run(&self) -> Result<(), WebhookConsumerError> {
+        let semaphore = Arc::new(sync::Semaphore::new(self.max_concurrent_jobs));
+
+        loop {
+            let webhook_job = self.wait_for_job().await?;
+
+            // reqwest::Client internally wraps with Arc, so this allocation is cheap.
+            let client = self.client.clone();
+            let permit = semaphore.clone().acquire_owned().await.unwrap();
+
+            tokio::spawn(async move {
+                let result = process_webhook_job(client, webhook_job).await;
+                drop(permit);
+                result
+            });
+        }
+    }
+}
+
+/// A consumer to poll `PgQueue` and spawn tasks to process webhooks when a job becomes available.
+pub struct WebhookTransactionConsumer<'p> {
+    /// An identifier for this consumer. Used to mark jobs we have consumed.
+    name: String,
+    /// The queue we will be dequeuing jobs from.
+    queue: &'p PgQueue,
+    /// The interval for polling the queue.
+    poll_interval: time::Duration,
+    /// The client used for HTTP requests.
+    client: reqwest::Client,
+    /// Maximum number of concurrent jobs being processed.
+    max_concurrent_jobs: usize,
+}
+
+impl<'p> WebhookTransactionConsumer<'p> {
+    pub fn new(
+        name: &str,
+        queue: &'p PgQueue,
+        poll_interval: time::Duration,
+        request_timeout: time::Duration,
+        max_concurrent_jobs: usize,
+    ) -> Result<Self, WebhookConsumerError> {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(request_timeout)
+            .build()?;
+
+        Ok(Self {
+            name: name.to_owned(),
+            queue,
+            poll_interval,
+            client,
+            max_concurrent_jobs,
+        })
     }
 
     /// Wait until a job becomes available in our queue.
@@ -254,6 +312,66 @@ async fn process_webhook_job<W: WebhookJob>(
                 .fail(WebhookJobError::from(&error))
                 .await
                 .map_err(|job_error| ConsumerError::PgJobError(job_error.to_string()))?;
+            Ok(())
+        }
+    }
+}
+
+/// Process a webhook job by transitioning it to its appropriate state after its request is sent.
+/// After we finish, the webhook job will be set as completed (if the request was successful), retryable (if the request
+/// was unsuccessful but we can still attempt a retry), or failed (if the request was unsuccessful and no more retries
+/// may be attempted).
+///
+/// A webhook job is considered retryable after a failing request if:
+/// 1. The job has attempts remaining (i.e. hasn't reached `max_attempts`), and...
+/// 2. The status code indicates retrying at a later point could resolve the issue. This means: 429 and any 5XX.
+///
+/// # Arguments
+///
+/// * `webhook_job`: The webhook job to process as dequeued from `hook_common::pgqueue::PgQueue`.
+/// * `request_timeout`: A timeout for the HTTP request.
+async fn process_webhook_job(
+    client: reqwest::Client,
+    webhook_job: PgJob<WebhookJobParameters>,
+) -> Result<(), WebhookConsumerError> {
+    match send_webhook(
+        client,
+        &webhook_job.job.parameters.method,
+        &webhook_job.job.parameters.url,
+        &webhook_job.job.parameters.headers,
+        webhook_job.job.parameters.body.clone(),
+    )
+    .await
+    {
+        Ok(_) => {
+            webhook_job
+                .complete()
+                .await
+                .map_err(|error| WebhookConsumerError::PgJobError(error.to_string()))?;
+            Ok(())
+        }
+        Err(WebhookConsumerError::RetryableWebhookError {
+            reason,
+            retry_after,
+        }) => match webhook_job.retry(reason.to_string(), retry_after).await {
+            Ok(_) => Ok(()),
+            Err(PgJobError::RetryInvalidError {
+                job: webhook_job,
+                error: fail_error,
+            }) => {
+                webhook_job
+                    .fail(fail_error.to_string())
+                    .await
+                    .map_err(|job_error| WebhookConsumerError::PgJobError(job_error.to_string()))?;
+                Ok(())
+            }
+            Err(job_error) => Err(WebhookConsumerError::PgJobError(job_error.to_string())),
+        },
+        Err(error) => {
+            webhook_job
+                .fail(error.to_string())
+                .await
+                .map_err(|job_error| WebhookConsumerError::PgJobError(job_error.to_string()))?;
             Ok(())
         }
     }

--- a/hook-consumer/src/main.rs
+++ b/hook-consumer/src/main.rs
@@ -1,6 +1,6 @@
 use envconfig::Envconfig;
 
-use hook_common::pgqueue::{PgQueue, RetryPolicy};
+use hook_common::{pgqueue::PgQueue, retry::RetryPolicy};
 use hook_consumer::config::Config;
 use hook_consumer::consumer::WebhookConsumer;
 use hook_consumer::error::ConsumerError;
@@ -14,14 +14,9 @@ async fn main() -> Result<(), ConsumerError> {
         config.retry_policy.initial_interval.0,
         Some(config.retry_policy.maximum_interval.0),
     );
-    let queue = PgQueue::new(
-        &config.queue_name,
-        &config.table_name,
-        &config.database_url,
-        retry_policy,
-    )
-    .await
-    .expect("failed to initialize queue");
+    let queue = PgQueue::new(&config.queue_name, &config.table_name, &config.database_url)
+        .await
+        .expect("failed to initialize queue");
 
     let consumer = WebhookConsumer::new(
         &config.consumer_name,

--- a/hook-consumer/src/main.rs
+++ b/hook-consumer/src/main.rs
@@ -24,6 +24,7 @@ async fn main() -> Result<(), ConsumerError> {
         config.poll_interval.0,
         config.request_timeout.0,
         config.max_concurrent_jobs,
+        retry_policy,
     );
 
     consumer.run(config.transactional).await?;

--- a/hook-producer/src/handlers/app.rs
+++ b/hook-producer/src/handlers/app.rs
@@ -31,7 +31,7 @@ mod tests {
         body::Body,
         http::{Request, StatusCode},
     };
-    use hook_common::pgqueue::{PgQueue, RetryPolicy};
+    use hook_common::pgqueue::PgQueue;
     use http_body_util::BodyExt; // for `collect`
     use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
 
@@ -41,7 +41,6 @@ mod tests {
             "test_index",
             "job_queue",
             "postgres://posthog:posthog@localhost:15432/test_database",
-            RetryPolicy::default(),
         )
         .await
         .expect("failed to construct pg_queue");

--- a/hook-producer/src/handlers/webhook.rs
+++ b/hook-producer/src/handlers/webhook.rs
@@ -108,7 +108,7 @@ mod tests {
         body::Body,
         http::{self, Request, StatusCode},
     };
-    use hook_common::pgqueue::{PgQueue, RetryPolicy};
+    use hook_common::pgqueue::PgQueue;
     use hook_common::webhook::{HttpMethod, WebhookJobParameters};
     use http_body_util::BodyExt; // for `collect`
     use std::collections;
@@ -122,7 +122,6 @@ mod tests {
             "test_index",
             "job_queue",
             "postgres://posthog:posthog@localhost:15432/test_database",
-            RetryPolicy::default(),
         )
         .await
         .expect("failed to construct pg_queue");
@@ -171,7 +170,6 @@ mod tests {
             "test_index",
             "job_queue",
             "postgres://posthog:posthog@localhost:15432/test_database",
-            RetryPolicy::default(),
         )
         .await
         .expect("failed to construct pg_queue");
@@ -215,7 +213,6 @@ mod tests {
             "test_index",
             "job_queue",
             "postgres://posthog:posthog@localhost:15432/test_database",
-            RetryPolicy::default(),
         )
         .await
         .expect("failed to construct pg_queue");
@@ -243,7 +240,6 @@ mod tests {
             "test_index",
             "job_queue",
             "postgres://posthog:posthog@localhost:15432/test_database",
-            RetryPolicy::default(),
         )
         .await
         .expect("failed to construct pg_queue");
@@ -271,7 +267,6 @@ mod tests {
             "test_index",
             "job_queue",
             "postgres://posthog:posthog@localhost:15432/test_database",
-            RetryPolicy::default(),
         )
         .await
         .expect("failed to construct pg_queue");

--- a/hook-producer/src/main.rs
+++ b/hook-producer/src/main.rs
@@ -4,7 +4,7 @@ use envconfig::Envconfig;
 use eyre::Result;
 
 use hook_common::metrics;
-use hook_common::pgqueue::{PgQueue, RetryPolicy};
+use hook_common::pgqueue::PgQueue;
 
 mod config;
 mod handlers;
@@ -29,8 +29,6 @@ async fn main() {
         &config.queue_name,
         &config.table_name,
         &config.database_url,
-        // TODO: It seems unnecessary that the producer side needs to know about the retry policy.
-        RetryPolicy::default(),
     )
     .await
     .expect("failed to initialize queue");


### PR DESCRIPTION
`PgQueue` only takes a `RetryPolicy` to pass it to Jobs. In reality, only the consumer needs to know the retry policy when retrying a job. So, let's remove `RetryPolicy` from `PgQueue`, and instead take it in the consumer. Then, `retry` methods just take a duration until next retry. 