### PR TITLE
Append final errors to error array and treat request errors as retryable

### DIFF
--- a/hook-common/src/pgqueue.rs
+++ b/hook-common/src/pgqueue.rs
@@ -248,6 +248,7 @@ UPDATE
 SET
     finished_at = NOW(),
     status = 'failed'::job_status
+    errors = array_append("{0}".errors, $3)
 WHERE
     "{0}".id = $2
     AND queue = $1
@@ -261,6 +262,7 @@ RETURNING
         sqlx::query(&base_query)
             .bind(&failed_job.queue)
             .bind(failed_job.id)
+            .bind(&failed_job.error)
             .execute(&mut *self.connection)
             .await
             .map_err(|error| PgJobError::QueryError {
@@ -394,6 +396,7 @@ UPDATE
 SET
     finished_at = NOW(),
     status = 'failed'::job_status
+    errors = array_append("{0}".errors, $3)
 WHERE
     "{0}".id = $2
     AND queue = $1
@@ -406,6 +409,7 @@ RETURNING
         sqlx::query(&base_query)
             .bind(&failed_job.queue)
             .bind(failed_job.id)
+            .bind(&failed_job.error)
             .execute(&mut *self.transaction)
             .await
             .map_err(|error| PgJobError::QueryError {

--- a/hook-consumer/src/consumer.rs
+++ b/hook-consumer/src/consumer.rs
@@ -32,7 +32,7 @@ impl<'p> WebhookConsumer<'p> {
         poll_interval: time::Duration,
         request_timeout: time::Duration,
         max_concurrent_jobs: usize,
-    ) -> Result<Self, WebhookConsumerError> {
+    ) -> Self {
         let mut headers = header::HeaderMap::new();
         headers.insert(
             header::CONTENT_TYPE,
@@ -45,13 +45,13 @@ impl<'p> WebhookConsumer<'p> {
             .build()
             .expect("failed to construct reqwest client for webhook consumer");
 
-        Ok(Self {
+        Self {
             name: name.to_owned(),
             queue,
             poll_interval,
             client,
             max_concurrent_jobs,
-        })
+        }
     }
 
     /// Wait until a job becomes available in our queue.
@@ -333,8 +333,8 @@ mod tests {
             time::Duration::from_millis(100),
             time::Duration::from_millis(5000),
             10,
-        )
-        .expect("consumer failed to initialize");
+        );
+
         let consumed_job = consumer
             .wait_for_job()
             .await

--- a/hook-consumer/src/consumer.rs
+++ b/hook-consumer/src/consumer.rs
@@ -42,7 +42,8 @@ impl<'p> WebhookConsumer<'p> {
         let client = reqwest::Client::builder()
             .default_headers(headers)
             .timeout(request_timeout)
-            .build()?;
+            .build()
+            .expect("failed to construct reqwest client for webhook consumer");
 
         Ok(Self {
             name: name.to_owned(),
@@ -174,7 +175,11 @@ async fn send_webhook(
         .headers(headers)
         .body(body)
         .send()
-        .await?;
+        .await
+        .map_err(|e| WebhookConsumerError::RetryableWebhookError {
+            reason: e.to_string(),
+            retry_after: None,
+        })?;
 
     let status = response.status();
 

--- a/hook-consumer/src/error.rs
+++ b/hook-consumer/src/error.rs
@@ -18,8 +18,6 @@ pub enum WebhookConsumerError {
     QueueError(#[from] pgqueue::PgQueueError),
     #[error("an error occurred in the underlying job")]
     PgJobError(String),
-    #[error("an error occurred when attempting to send a request")]
-    RequestError(#[from] reqwest::Error),
     #[error("a webhook could not be delivered but it could be retried later: {reason}")]
     RetryableWebhookError {
         reason: String,

--- a/hook-consumer/src/main.rs
+++ b/hook-consumer/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), WebhookConsumerError> {
         config.poll_interval.0,
         config.request_timeout.0,
         config.max_concurrent_jobs,
-    )?;
+    );
 
     let _ = consumer.run().await;
 


### PR DESCRIPTION
I've been working on the janitor and noticed 2 issues:

1. We don't append the error on `fail` when it seems like we should.
2. We were treating request errors as different from `RetryableWebhookError`, but we want things like connection errors, timeouts etc to be `RetryableWebhookError` AFAIK