### PR TITLE
feat: Use new WebhookJobError struct for error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,13 +100,13 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4353121d5644cdf2beb5726ab752e79a8db1ebb52031770ec47db31d245526"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.1.1",
  "async-executor",
- "async-io 2.2.1",
+ "async-io 2.2.2",
  "async-lock 3.2.0",
  "blocking",
  "futures-lite 2.1.0",
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d3b15875ba253d1110c740755e246537483f152fa334f91abd7fe84c88b3ff"
+checksum = "6afaa937395a620e33dc6a742c593c01aced20aa376ffb0f628121198578ccc7"
 dependencies = [
  "async-lock 3.2.0",
  "cfg-if",
@@ -146,7 +146,7 @@ dependencies = [
  "futures-lite 2.1.0",
  "parking",
  "polling 3.3.1",
- "rustix 0.38.27",
+ "rustix 0.38.28",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eb2cdb97421e01129ccb49169d8279ed21e829929144f4a22a6e54ac549ca1"
+checksum = "e1d90cd0b264dfdd8eb5bad0a2c217c1f88fa96a8573f40e7b12de23fb468f46"
 
 [[package]]
 name = "async-trait"
@@ -212,7 +212,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -265,7 +265,7 @@ dependencies = [
  "http 1.0.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.0.1",
+ "hyper 1.1.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation"
@@ -485,22 +485,21 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+checksum = "b9bcf5bdbfdd6030fb4a1c497b5d5fc5921aa2f60d359a17e249c0e6df3de153"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -508,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
 dependencies = [
  "cfg-if",
 ]
@@ -648,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbb8258be8305fb0237d7b295f47bb24ff1b136a535f473baf40e70468515aa"
+checksum = "b6267a1fa6f59179ea4afc8e50fd8612a3cc60bc858f786ff877a4a8cb042799"
 dependencies = [
  "indenter",
  "once_cell",
@@ -813,7 +812,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -980,9 +979,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac",
 ]
@@ -998,11 +997,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1015,6 +1014,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "regex",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http 0.2.11",
@@ -1161,9 +1161,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1171,12 +1171,12 @@ dependencies = [
  "futures-util",
  "h2 0.3.22",
  "http 0.2.11",
- "http-body 0.4.5",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1185,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f9214f3e703236b221f1a9cd88ec8b4adfa5296de01ab96216361f4692f56"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1209,7 +1209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -1226,7 +1226,7 @@ dependencies = [
  "futures-util",
  "http 1.0.0",
  "http-body 1.0.0",
- "hyper 1.0.1",
+ "hyper 1.1.0",
  "pin-project-lite",
  "socket2 0.5.5",
  "tokio",
@@ -1331,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
@@ -1364,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libm"
@@ -1481,12 +1481,12 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
+checksum = "1d4fa7ce7c4862db464a37b0b31d89bca874562f034bd7993895572783d02950"
 dependencies = [
  "base64",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "indexmap 1.9.3",
  "ipnet",
  "metrics",
@@ -1505,7 +1505,7 @@ checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1721,7 +1721,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1815,7 +1815,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1893,7 +1893,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.27",
+ "rustix 0.38.28",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -2065,9 +2065,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
  "base64",
  "bytes",
@@ -2076,8 +2076,8 @@ dependencies = [
  "futures-util",
  "h2 0.3.22",
  "http 0.2.11",
- "http-body 0.4.5",
- "hyper 0.14.27",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2143,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.27"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfeae074e687625746172d639330f1de242a178bf3189b51e35a7a21573513ac"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -2162,9 +2162,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "schannel"
@@ -2221,7 +2221,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2620,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2665,28 +2665,28 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
  "redox_syscall",
- "rustix 0.38.27",
+ "rustix 0.38.28",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2716,9 +2716,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2741,7 +2741,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2844,7 +2844,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -3020,7 +3020,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
  "wasm-bindgen-shared",
 ]
 
@@ -3054,7 +3054,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3246,9 +3246,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.28"
+version = "0.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
+checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
  "memchr",
 ]
@@ -3265,22 +3265,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.29"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d075cf85bbb114e933343e087b92f2146bac0d55b534cbb8188becf0039948e"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.29"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cd5ca076997b97ef09d3ad65efe811fa68c9e874cb636ccb211223a813b0c2"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ http-body-util = "0.1.0"
 metrics = "0.21.1"
 metrics-exporter-prometheus = "0.12.1"
 rdkafka = { version = "0.35.0", features = ["cmake-build", "ssl"] }
+reqwest = { version = "0.11" }
 regex = "1.10.2"
 serde = { version = "1.0" }
 serde_derive = { version = "1.0" }

--- a/hook-common/Cargo.toml
+++ b/hook-common/Cargo.toml
@@ -11,6 +11,7 @@ chrono = { workspace = true }
 http = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
+reqwest = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/hook-common/src/kafka_messages/app_metrics.rs
+++ b/hook-common/src/kafka_messages/app_metrics.rs
@@ -13,14 +13,16 @@ pub enum AppMetricCategory {
     ComposeWebhook,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub enum ErrorType {
     Timeout,
     Connection,
     HttpStatus(u16),
+    Parse,
+    MaxAttempts,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct ErrorDetails {
     pub error: Error,
     // TODO: The plugin-server sends the entire raw event with errors. In order to do this, we'll
@@ -30,7 +32,7 @@ pub struct ErrorDetails {
     // event: Value,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct Error {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -84,6 +86,8 @@ where
         ErrorType::Connection => "Connection Error".to_owned(),
         ErrorType::Timeout => "Timeout".to_owned(),
         ErrorType::HttpStatus(s) => format!("HTTP Status: {}", s),
+        ErrorType::Parse => "Parse Error".to_owned(),
+        ErrorType::MaxAttempts => "Maximum attempts exceeded".to_owned(),
     };
     serializer.serialize_str(&error_type)
 }

--- a/hook-common/src/kafka_messages/app_metrics.rs
+++ b/hook-common/src/kafka_messages/app_metrics.rs
@@ -19,7 +19,6 @@ pub enum ErrorType {
     Connection,
     HttpStatus(u16),
     Parse,
-    MaxAttempts,
 }
 
 #[derive(Serialize, Debug)]
@@ -87,7 +86,6 @@ where
         ErrorType::Timeout => "Timeout".to_owned(),
         ErrorType::HttpStatus(s) => format!("HTTP Status: {}", s),
         ErrorType::Parse => "Parse Error".to_owned(),
-        ErrorType::MaxAttempts => "Maximum attempts exceeded".to_owned(),
     };
     serializer.serialize_str(&error_type)
 }

--- a/hook-common/src/kafka_messages/mod.rs
+++ b/hook-common/src/kafka_messages/mod.rs
@@ -5,14 +5,14 @@ use chrono::{DateTime, Utc};
 use serde::Serializer;
 use uuid::Uuid;
 
-fn serialize_uuid<S>(uuid: &Uuid, serializer: S) -> Result<S::Ok, S::Error>
+pub fn serialize_uuid<S>(uuid: &Uuid, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
     serializer.serialize_str(&uuid.to_string())
 }
 
-fn serialize_datetime<S>(datetime: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+pub fn serialize_datetime<S>(datetime: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {

--- a/hook-common/src/webhook.rs
+++ b/hook-common/src/webhook.rs
@@ -138,6 +138,7 @@ pub struct WebhookJobMetadata {
 }
 
 /// An error originating during a Webhook Job invocation.
+/// This is to be serialized to be stored as an error whenever retrying or failing a webhook job.
 #[derive(Serialize, Debug)]
 pub struct WebhookJobError {
     pub r#type: app_metrics::ErrorType,
@@ -146,6 +147,9 @@ pub struct WebhookJobError {
     pub uuid: uuid::Uuid,
 }
 
+/// Webhook jobs boil down to an HTTP request, so it's useful to have a way to convert from &reqwest::Error.
+/// For the convertion we check all possible error types with the associated is_* methods provided by reqwest.
+/// Some precision may be lost as our app_metrics::ErrorType does not support the same number of variants.
 impl From<&reqwest::Error> for WebhookJobError {
     fn from(error: &reqwest::Error) -> Self {
         if error.is_body() || error.is_decode() {

--- a/hook-common/src/webhook.rs
+++ b/hook-common/src/webhook.rs
@@ -146,8 +146,8 @@ pub struct WebhookJobError {
     pub uuid: uuid::Uuid,
 }
 
-impl From<reqwest::Error> for WebhookJobError {
-    fn from(error: reqwest::Error) -> Self {
+impl From<&reqwest::Error> for WebhookJobError {
+    fn from(error: &reqwest::Error) -> Self {
         if error.is_body() || error.is_decode() {
             WebhookJobError::new_parse(&error.to_string())
         } else if error.is_timeout() {
@@ -225,24 +225,6 @@ impl WebhookJobError {
         };
         Self {
             r#type: app_metrics::ErrorType::Parse,
-            details: app_metrics::ErrorDetails {
-                error: error_details,
-            },
-            uuid: uuid::Uuid::now_v7(),
-        }
-    }
-
-    pub fn new_max_attempts(max_attempts: i32) -> Self {
-        let error_details = app_metrics::Error {
-            name: "maximum attempts exceeded".to_owned(),
-            message: Some(format!(
-                "Exceeded maximum number of attempts ({}) for webhook",
-                max_attempts
-            )),
-            stack: None,
-        };
-        Self {
-            r#type: app_metrics::ErrorType::MaxAttempts,
             details: app_metrics::ErrorDetails {
                 error: error_details,
             },

--- a/hook-consumer/Cargo.toml
+++ b/hook-consumer/Cargo.toml
@@ -10,7 +10,7 @@ envconfig = { workspace = true }
 futures = "0.3"
 hook-common = { path = "../hook-common" }
 http = { version = "0.2" }
-reqwest = { version = "0.11" }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 sqlx = { workspace = true }

--- a/hook-consumer/src/consumer.rs
+++ b/hook-consumer/src/consumer.rs
@@ -98,8 +98,8 @@ impl<'p> WebhookConsumer<'p> {
 ///
 /// # Arguments
 ///
+/// * `client`: An HTTP client to execute the webhook job request.
 /// * `webhook_job`: The webhook job to process as dequeued from `hook_common::pgqueue::PgQueue`.
-/// * `request_timeout`: A timeout for the HTTP request.
 async fn process_webhook_job(
     client: reqwest::Client,
     webhook_job: PgTransactionJob<'_, WebhookJobParameters, WebhookJobMetadata>,
@@ -173,11 +173,11 @@ async fn process_webhook_job(
 ///
 /// # Arguments
 ///
+/// * `client`: An HTTP client to execute the HTTP request.
 /// * `method`: The HTTP method to use in the HTTP request.
 /// * `url`: The URL we are targetting with our request. Parsing this URL fail.
 /// * `headers`: Key, value pairs of HTTP headers in a `std::collections::HashMap`. Can fail if headers are not valid.
 /// * `body`: The body of the request. Ownership is required.
-/// * `timeout`: A timeout for the HTTP request.
 async fn send_webhook(
     client: reqwest::Client,
     method: &HttpMethod,

--- a/hook-consumer/src/consumer.rs
+++ b/hook-consumer/src/consumer.rs
@@ -4,12 +4,12 @@ use std::time;
 
 use async_std::task;
 use hook_common::pgqueue::{PgJobError, PgQueue, PgQueueError, PgTransactionJob};
-use hook_common::webhook::{HttpMethod, WebhookJobMetadata, WebhookJobParameters};
+use hook_common::webhook::{HttpMethod, WebhookJobError, WebhookJobMetadata, WebhookJobParameters};
 use http::StatusCode;
 use reqwest::header;
 use tokio::sync;
 
-use crate::error::WebhookConsumerError;
+use crate::error::{ConsumerError, WebhookError};
 
 /// A consumer to poll `PgQueue` and spawn tasks to process webhooks when a job becomes available.
 pub struct WebhookConsumer<'p> {
@@ -57,8 +57,7 @@ impl<'p> WebhookConsumer<'p> {
     /// Wait until a job becomes available in our queue.
     async fn wait_for_job<'a>(
         &self,
-    ) -> Result<PgTransactionJob<'a, WebhookJobParameters, WebhookJobMetadata>, WebhookConsumerError>
-    {
+    ) -> Result<PgTransactionJob<'a, WebhookJobParameters, WebhookJobMetadata>, ConsumerError> {
         loop {
             if let Some(job) = self.queue.dequeue_tx(&self.name).await? {
                 return Ok(job);
@@ -69,7 +68,7 @@ impl<'p> WebhookConsumer<'p> {
     }
 
     /// Run this consumer to continuously process any jobs that become available.
-    pub async fn run(&self) -> Result<(), WebhookConsumerError> {
+    pub async fn run(&self) -> Result<(), ConsumerError> {
         let semaphore = Arc::new(sync::Semaphore::new(self.max_concurrent_jobs));
 
         loop {
@@ -104,7 +103,7 @@ impl<'p> WebhookConsumer<'p> {
 async fn process_webhook_job(
     client: reqwest::Client,
     webhook_job: PgTransactionJob<'_, WebhookJobParameters, WebhookJobMetadata>,
-) -> Result<(), WebhookConsumerError> {
+) -> Result<(), ConsumerError> {
     match send_webhook(
         client,
         &webhook_job.job.parameters.method,
@@ -118,31 +117,54 @@ async fn process_webhook_job(
             webhook_job
                 .complete()
                 .await
-                .map_err(|error| WebhookConsumerError::PgJobError(error.to_string()))?;
+                .map_err(|error| ConsumerError::PgJobError(error.to_string()))?;
             Ok(())
         }
-        Err(WebhookConsumerError::RetryableWebhookError {
-            reason,
-            retry_after,
-        }) => match webhook_job.retry(reason.to_string(), retry_after).await {
-            Ok(_) => Ok(()),
-            Err(PgJobError::RetryInvalidError {
-                job: webhook_job,
-                error: fail_error,
-            }) => {
-                webhook_job
-                    .fail(fail_error.to_string())
-                    .await
-                    .map_err(|job_error| WebhookConsumerError::PgJobError(job_error.to_string()))?;
-                Ok(())
-            }
-            Err(job_error) => Err(WebhookConsumerError::PgJobError(job_error.to_string())),
-        },
-        Err(error) => {
+        Err(WebhookError::ParseHeadersError(e)) => {
             webhook_job
-                .fail(error.to_string())
+                .fail(WebhookJobError::new_parse(&e.to_string()))
                 .await
-                .map_err(|job_error| WebhookConsumerError::PgJobError(job_error.to_string()))?;
+                .map_err(|job_error| ConsumerError::PgJobError(job_error.to_string()))?;
+            Ok(())
+        }
+        Err(WebhookError::ParseHttpMethodError(e)) => {
+            webhook_job
+                .fail(WebhookJobError::new_parse(&e))
+                .await
+                .map_err(|job_error| ConsumerError::PgJobError(job_error.to_string()))?;
+            Ok(())
+        }
+        Err(WebhookError::ParseUrlError(e)) => {
+            webhook_job
+                .fail(WebhookJobError::new_parse(&e.to_string()))
+                .await
+                .map_err(|job_error| ConsumerError::PgJobError(job_error.to_string()))?;
+            Ok(())
+        }
+        Err(WebhookError::RetryableRequestError { error, retry_after }) => {
+            match webhook_job
+                .retry(WebhookJobError::from(error), retry_after)
+                .await
+            {
+                Ok(_) => Ok(()),
+                Err(PgJobError::RetryInvalidError {
+                    job: webhook_job, ..
+                }) => {
+                    let max_attempts = webhook_job.job.max_attempts;
+                    webhook_job
+                        .fail(WebhookJobError::new_max_attempts(max_attempts))
+                        .await
+                        .map_err(|job_error| ConsumerError::PgJobError(job_error.to_string()))?;
+                    Ok(())
+                }
+                Err(job_error) => Err(ConsumerError::PgJobError(job_error.to_string())),
+            }
+        }
+        Err(WebhookError::NonRetryableRetryableRequestError(error)) => {
+            webhook_job
+                .fail(WebhookJobError::from(error))
+                .await
+                .map_err(|job_error| ConsumerError::PgJobError(job_error.to_string()))?;
             Ok(())
         }
     }
@@ -163,12 +185,12 @@ async fn send_webhook(
     url: &str,
     headers: &collections::HashMap<String, String>,
     body: String,
-) -> Result<reqwest::Response, WebhookConsumerError> {
+) -> Result<(), WebhookError> {
     let method: http::Method = method.into();
-    let url: reqwest::Url = (url).parse().map_err(WebhookConsumerError::ParseUrlError)?;
+    let url: reqwest::Url = (url).parse().map_err(WebhookError::ParseUrlError)?;
     let headers: reqwest::header::HeaderMap = (headers)
         .try_into()
-        .map_err(WebhookConsumerError::ParseHeadersError)?;
+        .map_err(WebhookError::ParseHeadersError)?;
     let body = reqwest::Body::from(body);
 
     let response = client
@@ -177,27 +199,28 @@ async fn send_webhook(
         .body(body)
         .send()
         .await
-        .map_err(|e| WebhookConsumerError::RetryableWebhookError {
-            reason: e.to_string(),
+        .map_err(|e| WebhookError::RetryableRequestError {
+            error: e,
             retry_after: None,
         })?;
 
-    let status = response.status();
+    match response.error_for_status_ref() {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            if is_retryable_status(
+                err.status()
+                    .expect("status code is set as error is generated from a response"),
+            ) {
+                let retry_after = parse_retry_after_header(response.headers());
 
-    if status.is_success() {
-        Ok(response)
-    } else if is_retryable_status(status) {
-        let retry_after = parse_retry_after_header(response.headers());
-
-        Err(WebhookConsumerError::RetryableWebhookError {
-            reason: format!("retryable status code {}", status),
-            retry_after,
-        })
-    } else {
-        Err(WebhookConsumerError::NonRetryableWebhookError(format!(
-            "non-retryable status code {}",
-            status
-        )))
+                Err(WebhookError::RetryableRequestError {
+                    error: err,
+                    retry_after,
+                })
+            } else {
+                Err(WebhookError::NonRetryableRetryableRequestError(err))
+            }
+        }
     }
 }
 

--- a/hook-consumer/src/error.rs
+++ b/hook-consumer/src/error.rs
@@ -3,26 +3,31 @@ use std::time;
 use hook_common::pgqueue;
 use thiserror::Error;
 
-/// Enumeration of errors for operations with WebhookConsumer.
+/// Enumeration of errors related to webhook job processing in the WebhookConsumer.
 #[derive(Error, Debug)]
-pub enum WebhookConsumerError {
-    #[error("timed out while waiting for jobs to be available")]
-    TimeoutError,
+pub enum WebhookError {
     #[error("{0} is not a valid HttpMethod")]
     ParseHttpMethodError(String),
     #[error("error parsing webhook headers")]
     ParseHeadersError(http::Error),
     #[error("error parsing webhook url")]
     ParseUrlError(url::ParseError),
+    #[error("a webhook could not be delivered but it could be retried later: {error}")]
+    RetryableRequestError {
+        error: reqwest::Error,
+        retry_after: Option<time::Duration>,
+    },
+    #[error("a webhook could not be delivered and it cannot be retried further: {0}")]
+    NonRetryableRetryableRequestError(reqwest::Error),
+}
+
+/// Enumeration of errors related to initialization and consumption of webhook jobs.
+#[derive(Error, Debug)]
+pub enum ConsumerError {
+    #[error("timed out while waiting for jobs to be available")]
+    TimeoutError,
     #[error("an error occurred in the underlying queue")]
     QueueError(#[from] pgqueue::PgQueueError),
     #[error("an error occurred in the underlying job")]
     PgJobError(String),
-    #[error("a webhook could not be delivered but it could be retried later: {reason}")]
-    RetryableWebhookError {
-        reason: String,
-        retry_after: Option<time::Duration>,
-    },
-    #[error("a webhook could not be delivered and it cannot be retried further: {0}")]
-    NonRetryableWebhookError(String),
 }

--- a/hook-consumer/src/main.rs
+++ b/hook-consumer/src/main.rs
@@ -3,10 +3,10 @@ use envconfig::Envconfig;
 use hook_common::pgqueue::{PgQueue, RetryPolicy};
 use hook_consumer::config::Config;
 use hook_consumer::consumer::WebhookConsumer;
-use hook_consumer::error::WebhookConsumerError;
+use hook_consumer::error::ConsumerError;
 
 #[tokio::main]
-async fn main() -> Result<(), WebhookConsumerError> {
+async fn main() -> Result<(), ConsumerError> {
     let config = Config::init_from_env().expect("Invalid configuration:");
 
     let retry_policy = RetryPolicy::new(


### PR DESCRIPTION
Instead of passing errors just as strings, we should support the `app_metrics` error schema and use a struct with `type`, `details`, and `uuid` fields; a new `WebhookJobError` was added to support this schema. Consumer now passes the new struct to `fail` and `retry` calls. These methods were already implemented generically over anything that can be serialized to json, so no changes required from that side to support a struct instead of `String`.

TODO: Should the UUID have any meaning? I've included it mostly to support the `app_metrics` schema, but I'm generating a new one on every error, so it's not very useful information (at least for now).