### PR TITLE
feat: Implement support for retrying jobs to different queue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target
+docker
+.env
+.git
+.github

--- a/.github/workflows/docker-hook-consumer.yml
+++ b/.github/workflows/docker-hook-consumer.yml
@@ -1,0 +1,63 @@
+name: Build hook-consumer docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    name: build and publish hook-consumer image
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    steps:
+
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/hook-consumer
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push consumer
+        id: docker_build_hook_consumer
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: BIN=hook-consumer
+
+      - name: Hook-consumer image digest
+        run: echo ${{ steps.docker_build_hook_consumer.outputs.digest }}

--- a/.github/workflows/docker-hook-janitor.yml
+++ b/.github/workflows/docker-hook-janitor.yml
@@ -1,0 +1,63 @@
+name: Build hook-janitor docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    name: build and publish hook-janitor image
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    steps:
+
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/hook-janitor
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push janitor
+        id: docker_build_hook_janitor
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: BIN=hook-janitor
+
+      - name: Hook-janitor image digest
+        run: echo ${{ steps.docker_build_hook_janitor.outputs.digest }}

--- a/.github/workflows/docker-hook-producer.yml
+++ b/.github/workflows/docker-hook-producer.yml
@@ -1,0 +1,63 @@
+name: Build hook-producer docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    name: build and publish hook-producer image
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    steps:
+
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/hook-producer
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push producer
+        id: docker_build_hook_producer
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: BIN=hook-producer
+
+      - name: Hook-producer image digest
+        run: echo ${{ steps.docker_build_hook_producer.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM docker.io/lukemathwalker/cargo-chef:latest-rust-1.74.0-buster AS chef
+ARG BIN
+WORKDIR app
+
+FROM chef AS planner
+ARG BIN
+
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json --bin $BIN
+
+FROM chef AS builder
+ARG BIN
+
+# Ensure working C compile setup (not installed by default in arm64 images)
+RUN apt update && apt install build-essential cmake -y
+
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+COPY . .
+RUN cargo build --release --bin $BIN
+
+FROM debian:bullseye-20230320-slim AS runtime
+ARG BIN
+ENV ENTRYPOINT=/usr/local/bin/$BIN
+WORKDIR app
+
+USER nobody
+
+COPY --from=builder /app/target/release/$BIN /usr/local/bin
+ENTRYPOINT [ $ENTRYPOINT ]

--- a/hook-common/src/pgqueue.rs
+++ b/hook-common/src/pgqueue.rs
@@ -109,7 +109,7 @@ impl<J, M> Job<J, M> {
         self.attempt >= self.max_attempts
     }
 
-    fn as_retryable(self) -> RetryableJob {
+    fn retryable(self) -> RetryableJob {
         RetryableJob {
             id: self.id,
             attempt: self.attempt,
@@ -146,7 +146,7 @@ RETURNING
 
         sqlx::query(&base_query)
             .bind(&self.queue)
-            .bind(&self.id)
+            .bind(self.id)
             .execute(executor)
             .await?;
 
@@ -192,7 +192,7 @@ RETURNING
 
         sqlx::query(&base_query)
             .bind(&self.queue)
-            .bind(&self.id)
+            .bind(self.id)
             .bind(&json_error)
             .execute(executor)
             .await?;
@@ -276,7 +276,7 @@ impl<J: std::marker::Send, M: std::marker::Send> PgQueueJob for PgJob<J, M> {
 
         let retried_job = self
             .job
-            .as_retryable()
+            .retryable()
             .queue(queue)
             .retry(error, retry_interval, &self.table, &mut *self.connection)
             .await
@@ -364,7 +364,7 @@ impl<'c, J: std::marker::Send, M: std::marker::Send> PgQueueJob for PgTransactio
 
         let retried_job = self
             .job
-            .as_retryable()
+            .retryable()
             .queue(queue)
             .retry(error, retry_interval, &self.table, &mut *self.transaction)
             .await
@@ -441,10 +441,10 @@ RETURNING
 
         sqlx::query(&base_query)
             .bind(&self.queue)
-            .bind(&self.id)
-            .bind(&retry_interval)
+            .bind(self.id)
+            .bind(retry_interval)
             .bind(&json_error)
-            .bind(&self.retry_queue())
+            .bind(self.retry_queue())
             .execute(executor)
             .await?;
 
@@ -461,7 +461,7 @@ RETURNING
 #[derive(Debug)]
 pub struct CompletedJob {
     /// A unique id identifying a job.
-    id: i64,
+    pub id: i64,
     /// A unique id identifying a job queue.
     pub queue: String,
 }
@@ -470,7 +470,7 @@ pub struct CompletedJob {
 #[derive(Debug)]
 pub struct RetriedJob {
     /// A unique id identifying a job.
-    id: i64,
+    pub id: i64,
     /// A unique id identifying a job queue.
     pub queue: String,
     pub retry_queue: Option<String>,
@@ -481,7 +481,7 @@ pub struct RetriedJob {
 #[derive(Debug)]
 pub struct FailedJob<J> {
     /// A unique id identifying a job.
-    id: i64,
+    pub id: i64,
     /// Any JSON-serializable value to be stored as an error.
     pub error: sqlx::types::Json<J>,
     /// A unique id identifying a job queue.

--- a/hook-common/src/pgqueue.rs
+++ b/hook-common/src/pgqueue.rs
@@ -891,7 +891,7 @@ mod tests {
         let table_name = "job_queue".to_owned();
         let queue_name = "test_can_retry_job_with_remaining_attempts".to_owned();
 
-        let retry_policy = RetryPolicy::new(0, time::Duration::from_secs(0))
+        let retry_policy = RetryPolicy::build(0, time::Duration::from_secs(0))
             .queue(&queue_name)
             .provide();
 
@@ -946,7 +946,7 @@ mod tests {
         let queue_name = "test_can_retry_job_to_different_queue".to_owned();
         let retry_queue_name = "test_can_retry_job_to_different_queue_retry".to_owned();
 
-        let retry_policy = RetryPolicy::new(0, time::Duration::from_secs(0))
+        let retry_policy = RetryPolicy::build(0, time::Duration::from_secs(0))
             .queue(&retry_queue_name)
             .provide();
 
@@ -1009,7 +1009,7 @@ mod tests {
         let job_metadata = JobMetadata::default();
         let worker_id = worker_id();
         let new_job = NewJob::new(1, job_metadata, job_parameters, &job_target);
-        let retry_policy = RetryPolicy::new(0, time::Duration::from_secs(0)).provide();
+        let retry_policy = RetryPolicy::build(0, time::Duration::from_secs(0)).provide();
 
         let queue = PgQueue::new_from_pool(
             "test_cannot_retry_job_without_remaining_attempts",

--- a/hook-common/src/retry.rs
+++ b/hook-common/src/retry.rs
@@ -14,7 +14,7 @@ pub struct RetryPolicy {
 }
 
 impl RetryPolicy {
-    pub fn new(backoff_coefficient: u32, initial_interval: time::Duration) -> RetryPolicyBuilder {
+    pub fn build(backoff_coefficient: u32, initial_interval: time::Duration) -> RetryPolicyBuilder {
         RetryPolicyBuilder::new(backoff_coefficient, initial_interval)
     }
 
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn test_constant_retry_interval() {
-        let retry_policy = RetryPolicy::new(1, time::Duration::from_secs(2)).provide();
+        let retry_policy = RetryPolicy::build(1, time::Duration::from_secs(2)).provide();
         let first_interval = retry_policy.retry_interval(1, None);
         let second_interval = retry_policy.retry_interval(2, None);
         let third_interval = retry_policy.retry_interval(3, None);
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn test_retry_interval_never_exceeds_maximum() {
-        let retry_policy = RetryPolicy::new(2, time::Duration::from_secs(2))
+        let retry_policy = RetryPolicy::build(2, time::Duration::from_secs(2))
             .maximum_interval(time::Duration::from_secs(4))
             .provide();
         let first_interval = retry_policy.retry_interval(1, None);
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn test_retry_interval_increases_with_coefficient() {
-        let retry_policy = RetryPolicy::new(2, time::Duration::from_secs(2)).provide();
+        let retry_policy = RetryPolicy::build(2, time::Duration::from_secs(2)).provide();
         let first_interval = retry_policy.retry_interval(1, None);
         let second_interval = retry_policy.retry_interval(2, None);
         let third_interval = retry_policy.retry_interval(3, None);
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn test_retry_interval_respects_preferred() {
-        let retry_policy = RetryPolicy::new(1, time::Duration::from_secs(2)).provide();
+        let retry_policy = RetryPolicy::build(1, time::Duration::from_secs(2)).provide();
         let preferred = time::Duration::from_secs(999);
         let first_interval = retry_policy.retry_interval(1, Some(preferred));
         let second_interval = retry_policy.retry_interval(2, Some(preferred));
@@ -172,7 +172,7 @@ mod tests {
 
     #[test]
     fn test_retry_interval_ignores_small_preferred() {
-        let retry_policy = RetryPolicy::new(1, time::Duration::from_secs(5)).provide();
+        let retry_policy = RetryPolicy::build(1, time::Duration::from_secs(5)).provide();
         let preferred = time::Duration::from_secs(2);
         let first_interval = retry_policy.retry_interval(1, Some(preferred));
         let second_interval = retry_policy.retry_interval(2, Some(preferred));
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     fn test_retry_interval_ignores_large_preferred() {
-        let retry_policy = RetryPolicy::new(2, time::Duration::from_secs(2))
+        let retry_policy = RetryPolicy::build(2, time::Duration::from_secs(2))
             .maximum_interval(time::Duration::from_secs(4))
             .provide();
         let preferred = time::Duration::from_secs(10);
@@ -201,7 +201,7 @@ mod tests {
     #[test]
     fn test_returns_retry_queue_if_set() {
         let retry_queue_name = "retry_queue".to_owned();
-        let retry_policy = RetryPolicy::new(0, time::Duration::from_secs(0))
+        let retry_policy = RetryPolicy::build(0, time::Duration::from_secs(0))
             .queue(&retry_queue_name)
             .provide();
         let current_queue = "queue".to_owned();
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     fn test_returns_queue_if_retry_queue_not_set() {
-        let retry_policy = RetryPolicy::new(0, time::Duration::from_secs(0)).provide();
+        let retry_policy = RetryPolicy::build(0, time::Duration::from_secs(0)).provide();
         let current_queue = "queue".to_owned();
 
         assert_eq!(retry_policy.retry_queue(&current_queue), current_queue);

--- a/hook-common/src/retry.rs
+++ b/hook-common/src/retry.rs
@@ -25,10 +25,8 @@ impl RetryPolicy {
         attempt: u32,
         preferred_retry_interval: Option<time::Duration>,
     ) -> time::Duration {
-        let candidate_interval = self.initial_interval
-            * self
-                .backoff_coefficient
-                .pow(attempt.checked_sub(1).unwrap_or(0));
+        let candidate_interval =
+            self.initial_interval * self.backoff_coefficient.pow(attempt.saturating_sub(1));
 
         match (preferred_retry_interval, self.maximum_interval) {
             (Some(duration), Some(max_interval)) => {
@@ -53,7 +51,7 @@ impl RetryPolicy {
         if let Some(new_queue) = &self.queue {
             new_queue
         } else {
-            &current_queue
+            current_queue
         }
     }
 }

--- a/hook-common/src/retry.rs
+++ b/hook-common/src/retry.rs
@@ -1,7 +1,10 @@
+//! # Retry
+//!
+//! Module providing a `RetryPolicy` struct to configure job retrying.
 use std::time;
 
 #[derive(Clone, Debug)]
-/// The retry policy that PgQueue will use to determine how to set scheduled_at when enqueuing a retry.
+/// A retry policy to determine retry parameters for a job.
 pub struct RetryPolicy {
     /// Coefficient to multiply initial_interval with for every past attempt.
     pub backoff_coefficient: u32,
@@ -14,12 +17,13 @@ pub struct RetryPolicy {
 }
 
 impl RetryPolicy {
+    /// Initialize a `RetryPolicyBuilder`.
     pub fn build(backoff_coefficient: u32, initial_interval: time::Duration) -> RetryPolicyBuilder {
         RetryPolicyBuilder::new(backoff_coefficient, initial_interval)
     }
 
-    /// Determine interval for retrying a given attempt number.
-    /// If provided, will try to respect a `preferred_retry_interval` as long as it falls within `candidate_interval <= preferred_retry_interval <= maximum_interval`.
+    /// Determine interval for retrying at a given attempt number.
+    /// If not `None`, this method will respect `preferred_retry_interval` as long as it falls within `candidate_interval <= preferred_retry_interval <= maximum_interval`.
     pub fn retry_interval(
         &self,
         attempt: u32,
@@ -62,6 +66,7 @@ impl Default for RetryPolicy {
     }
 }
 
+/// Builder pattern struct to provide a `RetryPolicy`.
 pub struct RetryPolicyBuilder {
     /// Coefficient to multiply initial_interval with for every past attempt.
     pub backoff_coefficient: u32,
@@ -103,6 +108,7 @@ impl RetryPolicyBuilder {
         self
     }
 
+    /// Provide a `RetryPolicy` according to build parameters provided thus far.
     pub fn provide(&self) -> RetryPolicy {
         RetryPolicy {
             backoff_coefficient: self.backoff_coefficient,

--- a/hook-common/src/retry.rs
+++ b/hook-common/src/retry.rs
@@ -1,6 +1,6 @@
 use std::time;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 /// The retry policy that PgQueue will use to determine how to set scheduled_at when enqueuing a retry.
 pub struct RetryPolicy {
     /// Coefficient to multiply initial_interval with for every past attempt.
@@ -9,22 +9,16 @@ pub struct RetryPolicy {
     pub initial_interval: time::Duration,
     /// The maximum possible backoff between retries.
     pub maximum_interval: Option<time::Duration>,
+    /// An optional queue to send WebhookJob retries to.
+    pub queue: Option<String>,
 }
 
 impl RetryPolicy {
-    pub fn new(
-        backoff_coefficient: u32,
-        initial_interval: time::Duration,
-        maximum_interval: Option<time::Duration>,
-    ) -> Self {
-        Self {
-            backoff_coefficient,
-            initial_interval,
-            maximum_interval,
-        }
+    pub fn new(backoff_coefficient: u32, initial_interval: time::Duration) -> RetryPolicyBuilder {
+        RetryPolicyBuilder::new(backoff_coefficient, initial_interval)
     }
 
-    /// Calculate the time until the next retry for a given RetryableJob.
+    /// Calculate the time until the next retry for a given attempt number.
     pub fn time_until_next_retry(
         &self,
         attempt: u32,
@@ -42,14 +36,72 @@ impl RetryPolicy {
             (None, None) => candidate_interval,
         }
     }
+
+    /// Determine the queue to be used for retrying.
+    /// Only whether a queue is configured in this RetryPolicy is used to determine which queue to use for retrying.
+    /// This may be extended in the future to support more decision parameters.
+    pub fn retry_queue<'s>(&'s self, current_queue: &'s str) -> &'s str {
+        if let Some(new_queue) = &self.queue {
+            new_queue
+        } else {
+            &current_queue
+        }
+    }
 }
 
 impl Default for RetryPolicy {
+    fn default() -> Self {
+        RetryPolicyBuilder::default().provide()
+    }
+}
+
+pub struct RetryPolicyBuilder {
+    /// Coefficient to multiply initial_interval with for every past attempt.
+    pub backoff_coefficient: u32,
+    /// The backoff interval for the first retry.
+    pub initial_interval: time::Duration,
+    /// The maximum possible backoff between retries.
+    pub maximum_interval: Option<time::Duration>,
+    /// An optional queue to send WebhookJob retries to.
+    pub queue: Option<String>,
+}
+
+impl Default for RetryPolicyBuilder {
     fn default() -> Self {
         Self {
             backoff_coefficient: 2,
             initial_interval: time::Duration::from_secs(1),
             maximum_interval: None,
+            queue: None,
+        }
+    }
+}
+
+impl RetryPolicyBuilder {
+    pub fn new(backoff_coefficient: u32, initial_interval: time::Duration) -> Self {
+        Self {
+            backoff_coefficient,
+            initial_interval,
+            ..RetryPolicyBuilder::default()
+        }
+    }
+
+    pub fn maximum_interval(mut self, interval: time::Duration) -> RetryPolicyBuilder {
+        self.maximum_interval = Some(interval);
+        self
+    }
+
+    pub fn queue(mut self, queue: &str) -> RetryPolicyBuilder {
+        self.queue = Some(queue.to_owned());
+        self
+    }
+
+    pub fn provide(&self) -> RetryPolicy {
+        RetryPolicy {
+            backoff_coefficient: self.backoff_coefficient,
+            initial_interval: self.initial_interval,
+            maximum_interval: self.maximum_interval,
+            queue: self.queue.clone(),
         }
     }
 }

--- a/hook-consumer/src/config.rs
+++ b/hook-consumer/src/config.rs
@@ -72,4 +72,7 @@ pub struct RetryPolicyConfig {
 
     #[envconfig(default = "100000")]
     pub maximum_interval: EnvMsDuration,
+
+    #[envconfig(default = "default")]
+    pub retry_queue_name: String,
 }

--- a/hook-consumer/src/consumer.rs
+++ b/hook-consumer/src/consumer.rs
@@ -13,7 +13,7 @@ use tokio::sync;
 
 use crate::error::{ConsumerError, WebhookError};
 
-/// A WebhookJob is any PgQueueJob with WebhookJobParameters and WebhookJobMetadata.
+/// A WebhookJob is any `PgQueueJob` with `WebhookJobParameters` and `WebhookJobMetadata`.
 trait WebhookJob: PgQueueJob + std::marker::Send {
     fn parameters(&self) -> &WebhookJobParameters;
     fn metadata(&self) -> &WebhookJobMetadata;
@@ -174,6 +174,7 @@ impl<'p> WebhookConsumer<'p> {
 ///
 /// * `client`: An HTTP client to execute the webhook job request.
 /// * `semaphore`: A semaphore used for rate limiting purposes. This function will panic if this semaphore is closed.
+/// * `retry_policy`: The retry policy used to set retry parameters if a job fails and has remaining attempts.
 /// * `webhook_job`: The webhook job to process as dequeued from `hook_common::pgqueue::PgQueue`.
 async fn spawn_webhook_job_processing_task<W: WebhookJob + 'static>(
     client: reqwest::Client,
@@ -213,6 +214,7 @@ async fn spawn_webhook_job_processing_task<W: WebhookJob + 'static>(
 ///
 /// * `client`: An HTTP client to execute the webhook job request.
 /// * `webhook_job`: The webhook job to process as dequeued from `hook_common::pgqueue::PgQueue`.
+/// * `retry_policy`: The retry policy used to set retry parameters if a job fails and has remaining attempts.
 async fn process_webhook_job<W: WebhookJob>(
     client: reqwest::Client,
     webhook_job: W,

--- a/hook-consumer/src/consumer.rs
+++ b/hook-consumer/src/consumer.rs
@@ -282,7 +282,7 @@ async fn process_webhook_job<W: WebhookJob>(
         }
         Err(WebhookError::RetryableRequestError { error, retry_after }) => {
             let retry_interval =
-                retry_policy.time_until_next_retry(webhook_job.attempt() as u32, retry_after);
+                retry_policy.retry_interval(webhook_job.attempt() as u32, retry_after);
             let current_queue = webhook_job.queue();
             let retry_queue = retry_policy.retry_queue(&current_queue);
 

--- a/hook-consumer/src/main.rs
+++ b/hook-consumer/src/main.rs
@@ -14,8 +14,10 @@ async fn main() -> Result<(), ConsumerError> {
     let retry_policy = RetryPolicy::new(
         config.retry_policy.backoff_coefficient,
         config.retry_policy.initial_interval.0,
-        Some(config.retry_policy.maximum_interval.0),
-    );
+    )
+    .maximum_interval(config.retry_policy.maximum_interval.0)
+    .queue(&config.retry_policy.retry_queue_name)
+    .provide();
     let queue = PgQueue::new(&config.queue_name, &config.table_name, &config.database_url)
         .await
         .expect("failed to initialize queue");

--- a/hook-consumer/src/main.rs
+++ b/hook-consumer/src/main.rs
@@ -11,7 +11,7 @@ use hook_consumer::error::ConsumerError;
 async fn main() -> Result<(), ConsumerError> {
     let config = Config::init_from_env().expect("Invalid configuration:");
 
-    let retry_policy = RetryPolicy::new(
+    let retry_policy = RetryPolicy::build(
         config.retry_policy.backoff_coefficient,
         config.retry_policy.initial_interval.0,
     )

--- a/hook-consumer/src/main.rs
+++ b/hook-consumer/src/main.rs
@@ -1,3 +1,4 @@
+//! Consume `PgQueue` jobs to run webhook calls.
 use envconfig::Envconfig;
 
 use hook_common::{


### PR DESCRIPTION
This PR implements separate queue retrying. `retry` methods now take a `retry_queue` which can be set to a different queue to set when updating the job. The `retry_queue` is provided by the `RetryPolicy`, which currently only returns a configured value if set. If nothing is set then `retry_queue` will just be the original job queue.

Also in this PR:
* Added tests for retry.rs.
* Fix some bugs in retry.rs.