### PR TITLE
feat: Add dockerfile to build any binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target
+docker
+.env
+.git
+.github

--- a/.github/workflows/docker-hook-consumer.yml
+++ b/.github/workflows/docker-hook-consumer.yml
@@ -1,0 +1,63 @@
+name: Build hook-consumer docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    name: build and publish hook-consumer image
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    steps:
+
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/hook-consumer
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push consumer
+        id: docker_build_hook_consumer
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: BIN=hook-consumer
+
+      - name: Hook-consumer image digest
+        run: echo ${{ steps.docker_build_hook_consumer.outputs.digest }}

--- a/.github/workflows/docker-hook-janitor.yml
+++ b/.github/workflows/docker-hook-janitor.yml
@@ -1,0 +1,63 @@
+name: Build hook-janitor docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    name: build and publish hook-janitor image
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    steps:
+
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/hook-janitor
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push janitor
+        id: docker_build_hook_janitor
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: BIN=hook-janitor
+
+      - name: Hook-janitor image digest
+        run: echo ${{ steps.docker_build_hook_janitor.outputs.digest }}

--- a/.github/workflows/docker-hook-producer.yml
+++ b/.github/workflows/docker-hook-producer.yml
@@ -1,0 +1,63 @@
+name: Build hook-producer docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    name: build and publish hook-producer image
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    steps:
+
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/hook-producer
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push producer
+        id: docker_build_hook_producer
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: BIN=hook-producer
+
+      - name: Hook-producer image digest
+        run: echo ${{ steps.docker_build_hook_producer.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM docker.io/lukemathwalker/cargo-chef:latest-rust-1.74.0-buster AS chef
+ARG BIN
+WORKDIR app
+
+FROM chef AS planner
+ARG BIN
+
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json --bin $BIN
+
+FROM chef AS builder
+ARG BIN
+
+# Ensure working C compile setup (not installed by default in arm64 images)
+RUN apt update && apt install build-essential cmake -y
+
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+COPY . .
+RUN cargo build --release --bin $BIN
+
+FROM debian:bullseye-20230320-slim AS runtime
+ARG BIN
+ENV ENTRYPOINT=/usr/local/bin/$BIN
+WORKDIR app
+
+USER nobody
+
+COPY --from=builder /app/target/release/$BIN /usr/local/bin
+ENTRYPOINT [ $ENTRYPOINT ]


### PR DESCRIPTION
A dockerfile mimicking [the one used in capture](https://github.com/PostHog/capture/blob/main/Dockerfile), but allowing for any binary (`hook-consumer`, `hook-producer`, or `hook-janitor` to be built).