### PR TITLE
 feat: Add github actions to build and publish images 

### DIFF
--- a/.github/workflows/docker-hook-consumer.yml
+++ b/.github/workflows/docker-hook-consumer.yml
@@ -1,0 +1,63 @@
+name: Build hook-consumer docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    name: build and publish hook-consumer image
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    steps:
+
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/hook-consumer
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push consumer
+        id: docker_build_hook_consumer
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: BIN=hook-consumer
+
+      - name: Hook-consumer image digest
+        run: echo ${{ steps.docker_build_hook_consumer.outputs.digest }}

--- a/.github/workflows/docker-hook-janitor.yml
+++ b/.github/workflows/docker-hook-janitor.yml
@@ -1,0 +1,63 @@
+name: Build hook-janitor docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    name: build and publish hook-janitor image
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    steps:
+
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/hook-janitor
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push janitor
+        id: docker_build_hook_janitor
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: BIN=hook-janitor
+
+      - name: Hook-janitor image digest
+        run: echo ${{ steps.docker_build_hook_janitor.outputs.digest }}

--- a/.github/workflows/docker-hook-producer.yml
+++ b/.github/workflows/docker-hook-producer.yml
@@ -1,0 +1,63 @@
+name: Build hook-producer docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    name: build and publish hook-producer image
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    steps:
+
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/hook-producer
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push producer
+        id: docker_build_hook_producer
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: BIN=hook-producer
+
+      - name: Hook-producer image digest
+        run: echo ${{ steps.docker_build_hook_producer.outputs.digest }}


### PR DESCRIPTION
Mimicking action from https://github.com/PostHog/capture/blob/main/.github/workflows/docker.yml, but using one for each image to make it easier to set tags (and potentially in the future set change paths).