### PR TITLE
fix: Add org name to image path

### DIFF
--- a/.github/workflows/docker-hook-consumer.yml
+++ b/.github/workflows/docker-hook-consumer.yml
@@ -25,7 +25,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/hook-consumer
+          images: ghcr.io/posthog/hook-consumer
           tags: |
             type=ref,event=pr
             type=ref,event=branch

--- a/.github/workflows/docker-hook-janitor.yml
+++ b/.github/workflows/docker-hook-janitor.yml
@@ -25,7 +25,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/hook-janitor
+          images: ghcr.io/posthog/hook-janitor
           tags: |
             type=ref,event=pr
             type=ref,event=branch

--- a/.github/workflows/docker-hook-producer.yml
+++ b/.github/workflows/docker-hook-producer.yml
@@ -25,7 +25,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/hook-producer
+          images: ghcr.io/posthog/hook-producer
           tags: |
             type=ref,event=pr
             type=ref,event=branch


### PR DESCRIPTION
This was missing and causes a 400 when pushing images.