### PR TITLE
refactor: Remove table name config and hardcode table name

### DIFF
--- a/hook-common/src/pgqueue.rs
+++ b/hook-common/src/pgqueue.rs
@@ -129,8 +129,7 @@ impl<J, M> Job<J, M> {
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
-        let base_query = format!(
-            r#"
+        let base_query = r#"
 UPDATE
     "job_queue"
 SET
@@ -141,10 +140,9 @@ WHERE
     AND queue = $1
 RETURNING
     "job_queue".*
-            "#,
-        );
+        "#;
 
-        sqlx::query(&base_query)
+        sqlx::query(base_query)
             .bind(&self.queue)
             .bind(self.id)
             .execute(executor)
@@ -169,8 +167,7 @@ RETURNING
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
         let json_error = sqlx::types::Json(error);
-        let base_query = format!(
-            r#"
+        let base_query = r#"
 UPDATE
     "job_queue"
 SET
@@ -182,10 +179,9 @@ WHERE
     AND queue = $1
 RETURNING
     "job_queue".*
-            "#,
-        );
+        "#;
 
-        sqlx::query(&base_query)
+        sqlx::query(base_query)
             .bind(&self.queue)
             .bind(self.id)
             .bind(&json_error)
@@ -423,8 +419,7 @@ impl RetryableJob {
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
         let json_error = sqlx::types::Json(error);
-        let base_query = format!(
-            r#"
+        let base_query = r#"
 UPDATE
     "job_queue"
 SET
@@ -438,10 +433,9 @@ WHERE
     AND queue = $1
 RETURNING
     "job_queue".*
-            "#,
-        );
+        "#;
 
-        sqlx::query(&base_query)
+        sqlx::query(base_query)
             .bind(&self.queue)
             .bind(self.id)
             .bind(retry_interval)
@@ -568,8 +562,7 @@ impl PgQueue {
 
         // The query that follows uses a FOR UPDATE SKIP LOCKED clause.
         // For more details on this see: 2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5.
-        let base_query = format!(
-            r#"
+        let base_query = r#"
 WITH available_in_queue AS (
     SELECT
         id
@@ -598,10 +591,9 @@ WHERE
     "job_queue".id = available_in_queue.id
 RETURNING
     "job_queue".*
-            "#,
-        );
+        "#;
 
-        let query_result: Result<Job<J, M>, sqlx::Error> = sqlx::query_as(&base_query)
+        let query_result: Result<Job<J, M>, sqlx::Error> = sqlx::query_as(base_query)
             .bind(&self.name)
             .bind(attempted_by)
             .fetch_one(&mut *connection)
@@ -645,8 +637,7 @@ RETURNING
 
         // The query that follows uses a FOR UPDATE SKIP LOCKED clause.
         // For more details on this see: 2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5.
-        let base_query = format!(
-            r#"
+        let base_query = r#"
 WITH available_in_queue AS (
     SELECT
         id
@@ -675,10 +666,9 @@ WHERE
     "job_queue".id = available_in_queue.id
 RETURNING
     "job_queue".*
-            "#,
-        );
+        "#;
 
-        let query_result: Result<Job<J, M>, sqlx::Error> = sqlx::query_as(&base_query)
+        let query_result: Result<Job<J, M>, sqlx::Error> = sqlx::query_as(base_query)
             .bind(&self.name)
             .bind(attempted_by)
             .fetch_one(&mut *tx)
@@ -709,16 +699,14 @@ RETURNING
         job: NewJob<J, M>,
     ) -> PgQueueResult<()> {
         // TODO: Escaping. I think sqlx doesn't support identifiers.
-        let base_query = format!(
-            r#"
+        let base_query = r#"
 INSERT INTO job_queue
     (attempt, created_at, scheduled_at, max_attempts, metadata, parameters, queue, status, target)
 VALUES
     (0, NOW(), NOW(), $1, $2, $3, $4, 'available'::job_status, $5)
-            "#,
-        );
+        "#;
 
-        sqlx::query(&base_query)
+        sqlx::query(base_query)
             .bind(job.max_attempts)
             .bind(&job.metadata)
             .bind(&job.parameters)

--- a/hook-consumer/src/config.rs
+++ b/hook-consumer/src/config.rs
@@ -34,9 +34,6 @@ pub struct Config {
 
     #[envconfig(default = "true")]
     pub transactional: bool,
-
-    #[envconfig(default = "job_queue")]
-    pub table_name: String,
 }
 
 impl Config {

--- a/hook-consumer/src/consumer.rs
+++ b/hook-consumer/src/consumer.rs
@@ -484,8 +484,7 @@ mod tests {
     async fn test_wait_for_job(db: PgPool) {
         let worker_id = worker_id();
         let queue_name = "test_wait_for_job".to_string();
-        let table_name = "job_queue".to_string();
-        let queue = PgQueue::new_from_pool(&queue_name, &table_name, db)
+        let queue = PgQueue::new_from_pool(&queue_name, db)
             .await
             .expect("failed to connect to PG");
 

--- a/hook-consumer/src/main.rs
+++ b/hook-consumer/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), ConsumerError> {
     .maximum_interval(config.retry_policy.maximum_interval.0)
     .queue(&config.retry_policy.retry_queue_name)
     .provide();
-    let queue = PgQueue::new(&config.queue_name, &config.table_name, &config.database_url)
+    let queue = PgQueue::new(&config.queue_name, &config.database_url)
         .await
         .expect("failed to initialize queue");
 

--- a/hook-janitor/src/config.rs
+++ b/hook-janitor/src/config.rs
@@ -11,9 +11,6 @@ pub struct Config {
     #[envconfig(default = "postgres://posthog:posthog@localhost:15432/test_database")]
     pub database_url: String,
 
-    #[envconfig(default = "job_queue")]
-    pub table_name: String,
-
     #[envconfig(default = "default")]
     pub queue_name: String,
 

--- a/hook-janitor/src/main.rs
+++ b/hook-janitor/src/main.rs
@@ -55,7 +55,6 @@ async fn main() {
             Box::new(
                 WebhookCleaner::new(
                     &config.queue_name,
-                    &config.table_name,
                     &config.database_url,
                     kafka_producer,
                     config.kafka.app_metrics_topic.to_owned(),

--- a/hook-producer/src/config.rs
+++ b/hook-producer/src/config.rs
@@ -11,9 +11,6 @@ pub struct Config {
     #[envconfig(default = "postgres://posthog:posthog@localhost:15432/test_database")]
     pub database_url: String,
 
-    #[envconfig(default = "job_queue")]
-    pub table_name: String,
-
     #[envconfig(default = "default")]
     pub queue_name: String,
 }

--- a/hook-producer/src/handlers/app.rs
+++ b/hook-producer/src/handlers/app.rs
@@ -38,7 +38,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn index(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", "job_queue", db)
+        let pg_queue = PgQueue::new_from_pool("test_index", db)
             .await
             .expect("failed to construct pg_queue");
 

--- a/hook-producer/src/handlers/webhook.rs
+++ b/hook-producer/src/handlers/webhook.rs
@@ -119,7 +119,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_success(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", "job_queue", db)
+        let pg_queue = PgQueue::new_from_pool("test_index", db)
             .await
             .expect("failed to construct pg_queue");
 
@@ -163,7 +163,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_bad_url(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", "job_queue", db)
+        let pg_queue = PgQueue::new_from_pool("test_index", db)
             .await
             .expect("failed to construct pg_queue");
 
@@ -202,7 +202,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_payload_missing_fields(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", "job_queue", db)
+        let pg_queue = PgQueue::new_from_pool("test_index", db)
             .await
             .expect("failed to construct pg_queue");
 
@@ -225,7 +225,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_payload_not_json(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", "job_queue", db)
+        let pg_queue = PgQueue::new_from_pool("test_index", db)
             .await
             .expect("failed to construct pg_queue");
 
@@ -248,7 +248,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_payload_body_too_large(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", "job_queue", db)
+        let pg_queue = PgQueue::new_from_pool("test_index", db)
             .await
             .expect("failed to construct pg_queue");
 

--- a/hook-producer/src/main.rs
+++ b/hook-producer/src/main.rs
@@ -27,7 +27,6 @@ async fn main() {
         // TODO: Coupling the queue name to the PgQueue object doesn't seem ideal from the producer
         // side, but we don't need more than one queue for now.
         &config.queue_name,
-        &config.table_name,
         &config.database_url,
     )
     .await


### PR DESCRIPTION
The table name `job_queue` is hard coded in the migration, but it's configurable (and can be messed up) in the services. This configuration doesn't seem to be used for anything in particular: Services just pass the value around to format queries. Since we don't have a use case currently for a configurable table name, let's hardcode it in the services' code too and remove some complexity.

Nothing against a configurable table name: If a usecase pops up in the future I'm happy to re-add this. In the meantime, this also makes things easier to mess up in deployment.