### PR TITLE
Sync default ports with charts

### DIFF
--- a/hook-api/src/config.rs
+++ b/hook-api/src/config.rs
@@ -5,7 +5,7 @@ pub struct Config {
     #[envconfig(from = "BIND_HOST", default = "0.0.0.0")]
     pub host: String,
 
-    #[envconfig(from = "BIND_PORT", default = "8000")]
+    #[envconfig(from = "BIND_PORT", default = "3300")]
     pub port: u16,
 
     #[envconfig(default = "postgres://posthog:posthog@localhost:15432/test_database")]

--- a/hook-janitor/src/config.rs
+++ b/hook-janitor/src/config.rs
@@ -5,7 +5,7 @@ pub struct Config {
     #[envconfig(from = "BIND_HOST", default = "0.0.0.0")]
     pub host: String,
 
-    #[envconfig(from = "BIND_PORT", default = "8000")]
+    #[envconfig(from = "BIND_PORT", default = "3302")]
     pub port: u16,
 
     #[envconfig(default = "postgres://posthog:posthog@localhost:15432/test_database")]

--- a/hook-worker/src/config.rs
+++ b/hook-worker/src/config.rs
@@ -8,7 +8,7 @@ pub struct Config {
     #[envconfig(from = "BIND_HOST", default = "0.0.0.0")]
     pub host: String,
 
-    #[envconfig(from = "BIND_PORT", default = "8001")]
+    #[envconfig(from = "BIND_PORT", default = "3301")]
     pub port: u16,
 
     #[envconfig(default = "postgres://posthog:posthog@localhost:15432/test_database")]


### PR DESCRIPTION
Charts uses `BIND_PORT` but we may as well avoid the collisions locally.

https://github.com/PostHog/charts/pull/642/files