### PR TITLE
fix: Bump failure counter on job error

### DIFF
--- a/hook-api/src/handlers/app.rs
+++ b/hook-api/src/handlers/app.rs
@@ -30,9 +30,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn index(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", db)
-            .await
-            .expect("failed to construct pg_queue");
+        let pg_queue = PgQueue::new_from_pool("test_index", db).await;
 
         let app = add_routes(Router::new(), pg_queue);
 

--- a/hook-api/src/handlers/webhook.rs
+++ b/hook-api/src/handlers/webhook.rs
@@ -127,9 +127,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_success(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", db)
-            .await
-            .expect("failed to construct pg_queue");
+        let pg_queue = PgQueue::new_from_pool("test_index", db).await;
 
         let app = add_routes(Router::new(), pg_queue);
 
@@ -171,9 +169,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_bad_url(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", db)
-            .await
-            .expect("failed to construct pg_queue");
+        let pg_queue = PgQueue::new_from_pool("test_index", db).await;
 
         let app = add_routes(Router::new(), pg_queue);
 
@@ -210,9 +206,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_payload_missing_fields(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", db)
-            .await
-            .expect("failed to construct pg_queue");
+        let pg_queue = PgQueue::new_from_pool("test_index", db).await;
 
         let app = add_routes(Router::new(), pg_queue);
 
@@ -233,9 +227,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_payload_not_json(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", db)
-            .await
-            .expect("failed to construct pg_queue");
+        let pg_queue = PgQueue::new_from_pool("test_index", db).await;
 
         let app = add_routes(Router::new(), pg_queue);
 
@@ -256,9 +248,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_payload_body_too_large(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", db)
-            .await
-            .expect("failed to construct pg_queue");
+        let pg_queue = PgQueue::new_from_pool("test_index", db).await;
 
         let app = add_routes(Router::new(), pg_queue);
 

--- a/hook-common/src/webhook.rs
+++ b/hook-common/src/webhook.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use serde::{de::Visitor, Deserialize, Serialize};
 
 use crate::kafka_messages::app_metrics;
-use crate::pgqueue::PgQueueError;
+use crate::pgqueue::ParseError;
 
 /// Supported HTTP methods for webhooks.
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -20,7 +20,7 @@ pub enum HttpMethod {
 
 /// Allow casting `HttpMethod` from strings.
 impl FromStr for HttpMethod {
-    type Err = PgQueueError;
+    type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_ascii_uppercase().as_ref() {
@@ -29,7 +29,7 @@ impl FromStr for HttpMethod {
             "PATCH" => Ok(HttpMethod::PATCH),
             "POST" => Ok(HttpMethod::POST),
             "PUT" => Ok(HttpMethod::PUT),
-            invalid => Err(PgQueueError::ParseHttpMethodError(invalid.to_owned())),
+            invalid => Err(ParseError::ParseHttpMethodError(invalid.to_owned())),
         }
     }
 }

--- a/hook-janitor/src/webhooks.rs
+++ b/hook-janitor/src/webhooks.rs
@@ -786,9 +786,7 @@ mod tests {
             WebhookCleaner::new_from_pool(db.clone(), mock_producer, APP_METRICS_TOPIC.to_owned())
                 .expect("unable to create webhook cleaner");
 
-        let queue = PgQueue::new_from_pool("webhooks", db.clone())
-            .await
-            .expect("failed to connect to local test postgresql database");
+        let queue = PgQueue::new_from_pool("webhooks", db.clone()).await;
 
         async fn get_count_from_new_conn(db: &PgPool, status: &str) -> i64 {
             let mut conn = db.acquire().await.unwrap();

--- a/hook-worker/src/error.rs
+++ b/hook-worker/src/error.rs
@@ -24,10 +24,10 @@ pub enum WebhookError {
 /// Enumeration of errors related to initialization and consumption of webhook jobs.
 #[derive(Error, Debug)]
 pub enum WorkerError {
+    #[error("a database error occurred when executing a job")]
+    DatabaseError(#[from] pgqueue::DatabaseError),
+    #[error("a parsing error occurred in the underlying queue")]
+    QueueParseError(#[from] pgqueue::ParseError),
     #[error("timed out while waiting for jobs to be available")]
     TimeoutError,
-    #[error("an error occurred in the underlying queue")]
-    QueueError(#[from] pgqueue::PgQueueError),
-    #[error("an error occurred in the underlying job: {0}")]
-    PgJobError(String),
 }

--- a/hook-worker/src/worker.rs
+++ b/hook-worker/src/worker.rs
@@ -247,7 +247,10 @@ async fn process_webhook_job<W: WebhookJob>(
             webhook_job
                 .fail(WebhookJobError::new_parse(&e.to_string()))
                 .await
-                .map_err(|job_error| WorkerError::PgJobError(job_error.to_string()))?;
+                .map_err(|job_error| {
+                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    WorkerError::PgJobError(job_error.to_string())
+                })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
 
@@ -257,7 +260,10 @@ async fn process_webhook_job<W: WebhookJob>(
             webhook_job
                 .fail(WebhookJobError::new_parse(&e))
                 .await
-                .map_err(|job_error| WorkerError::PgJobError(job_error.to_string()))?;
+                .map_err(|job_error| {
+                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    WorkerError::PgJobError(job_error.to_string())
+                })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
 
@@ -267,7 +273,10 @@ async fn process_webhook_job<W: WebhookJob>(
             webhook_job
                 .fail(WebhookJobError::new_parse(&e.to_string()))
                 .await
-                .map_err(|job_error| WorkerError::PgJobError(job_error.to_string()))?;
+                .map_err(|job_error| {
+                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    WorkerError::PgJobError(job_error.to_string())
+                })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
 
@@ -294,7 +303,10 @@ async fn process_webhook_job<W: WebhookJob>(
                     webhook_job
                         .fail(WebhookJobError::from(&error))
                         .await
-                        .map_err(|job_error| WorkerError::PgJobError(job_error.to_string()))?;
+                        .map_err(|job_error| {
+                            metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                            WorkerError::PgJobError(job_error.to_string())
+                        })?;
 
                     metrics::counter!("webhook_jobs_failed", &labels).increment(1);
 
@@ -307,7 +319,10 @@ async fn process_webhook_job<W: WebhookJob>(
             webhook_job
                 .fail(WebhookJobError::from(&error))
                 .await
-                .map_err(|job_error| WorkerError::PgJobError(job_error.to_string()))?;
+                .map_err(|job_error| {
+                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    WorkerError::PgJobError(job_error.to_string())
+                })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
 

--- a/hook-worker/src/worker.rs
+++ b/hook-worker/src/worker.rs
@@ -248,7 +248,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .fail(WebhookJobError::new_parse(&e.to_string()))
                 .await
                 .map_err(|job_error| {
-                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
                     WorkerError::PgJobError(job_error.to_string())
                 })?;
 
@@ -261,7 +261,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .fail(WebhookJobError::new_parse(&e))
                 .await
                 .map_err(|job_error| {
-                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
                     WorkerError::PgJobError(job_error.to_string())
                 })?;
 
@@ -274,7 +274,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .fail(WebhookJobError::new_parse(&e.to_string()))
                 .await
                 .map_err(|job_error| {
-                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
                     WorkerError::PgJobError(job_error.to_string())
                 })?;
 
@@ -304,7 +304,7 @@ async fn process_webhook_job<W: WebhookJob>(
                         .fail(WebhookJobError::from(&error))
                         .await
                         .map_err(|job_error| {
-                            metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                            metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
                             WorkerError::PgJobError(job_error.to_string())
                         })?;
 
@@ -312,7 +312,11 @@ async fn process_webhook_job<W: WebhookJob>(
 
                     Ok(())
                 }
-                Err(job_error) => Err(WorkerError::PgJobError(job_error.to_string())),
+                Err(job_error) => {
+                    metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
+
+                    Err(WorkerError::PgJobError(job_error.to_string()))
+                }
             }
         }
         Err(WebhookError::NonRetryableRetryableRequestError(error)) => {
@@ -320,7 +324,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .fail(WebhookJobError::from(&error))
                 .await
                 .map_err(|job_error| {
-                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
                     WorkerError::PgJobError(job_error.to_string())
                 })?;
 

--- a/hook-worker/src/worker.rs
+++ b/hook-worker/src/worker.rs
@@ -6,7 +6,9 @@ use futures::future::join_all;
 use hook_common::health::HealthHandle;
 use hook_common::pgqueue::PgTransactionBatch;
 use hook_common::{
-    pgqueue::{Job, PgJobError, PgQueue, PgQueueError, PgQueueJob, PgTransactionJob},
+    pgqueue::{
+        DatabaseError, Job, PgQueue, PgQueueJob, PgTransactionJob, RetryError, RetryInvalidError,
+    },
     retry::RetryPolicy,
     webhook::{HttpMethod, WebhookJobError, WebhookJobMetadata, WebhookJobParameters},
 };
@@ -232,10 +234,10 @@ async fn process_webhook_job<W: WebhookJob>(
 
     match send_result {
         Ok(_) => {
-            webhook_job
-                .complete()
-                .await
-                .map_err(|error| WorkerError::PgJobError(error.to_string()))?;
+            webhook_job.complete().await.map_err(|error| {
+                metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
+                error
+            })?;
 
             metrics::counter!("webhook_jobs_completed", &labels).increment(1);
             metrics::histogram!("webhook_jobs_processing_duration_seconds", &labels)
@@ -249,7 +251,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .await
                 .map_err(|job_error| {
                     metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
-                    WorkerError::PgJobError(job_error.to_string())
+                    job_error
                 })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
@@ -262,7 +264,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .await
                 .map_err(|job_error| {
                     metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
-                    WorkerError::PgJobError(job_error.to_string())
+                    job_error
                 })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
@@ -275,7 +277,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .await
                 .map_err(|job_error| {
                     metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
-                    WorkerError::PgJobError(job_error.to_string())
+                    job_error
                 })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
@@ -297,25 +299,24 @@ async fn process_webhook_job<W: WebhookJob>(
 
                     Ok(())
                 }
-                Err(PgJobError::RetryInvalidError {
+                Err(RetryError::RetryInvalidError(RetryInvalidError {
                     job: webhook_job, ..
-                }) => {
+                })) => {
                     webhook_job
                         .fail(WebhookJobError::from(&error))
                         .await
                         .map_err(|job_error| {
                             metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
-                            WorkerError::PgJobError(job_error.to_string())
+                            job_error
                         })?;
 
                     metrics::counter!("webhook_jobs_failed", &labels).increment(1);
 
                     Ok(())
                 }
-                Err(job_error) => {
+                Err(RetryError::DatabaseError(job_error)) => {
                     metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
-
-                    Err(WorkerError::PgJobError(job_error.to_string()))
+                    Err(WorkerError::from(job_error))
                 }
             }
         }
@@ -325,7 +326,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .await
                 .map_err(|job_error| {
                     metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
-                    WorkerError::PgJobError(job_error.to_string())
+                    job_error
                 })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
@@ -455,7 +456,7 @@ mod tests {
         max_attempts: i32,
         job_parameters: WebhookJobParameters,
         job_metadata: WebhookJobMetadata,
-    ) -> Result<(), PgQueueError> {
+    ) -> Result<(), DatabaseError> {
         let job_target = job_parameters.url.to_owned();
         let new_job = NewJob::new(max_attempts, job_metadata, job_parameters, &job_target);
         queue.enqueue(new_job).await?;
@@ -496,9 +497,7 @@ mod tests {
     async fn test_wait_for_job(db: PgPool) {
         let worker_id = worker_id();
         let queue_name = "test_wait_for_job".to_string();
-        let queue = PgQueue::new_from_pool(&queue_name, db)
-            .await
-            .expect("failed to connect to PG");
+        let queue = PgQueue::new_from_pool(&queue_name, db).await;
 
         let webhook_job_parameters = WebhookJobParameters {
             body: "a webhook job body. much wow.".to_owned(),


### PR DESCRIPTION
Also bump `webhook_jobs_failed` on job error. Maybe we should have a separate counter for this? `PgJobError` usually indicates something on our end, so it could be worth it to have a distinction.

EDIT: I've done that, there is now a `webhook_jobs_database_error` counter.