### PR TITLE
feat: Set idle tx timeout in migration

### DIFF
--- a/migrations/20231129172339_job_queue_table.sql
+++ b/migrations/20231129172339_job_queue_table.sql
@@ -27,3 +27,5 @@ CREATE INDEX idx_queue_scheduled_at ON job_queue(queue, status, scheduled_at, at
 
 -- Needed for UPDATE-ing incomplete jobs with a specific target (i.e. slow destinations)
 CREATE INDEX idx_queue_target ON job_queue(queue, status, target);
+
+SET idle_in_transaction_session_timeout='2min';

--- a/migrations/20231129172339_job_queue_table.sql
+++ b/migrations/20231129172339_job_queue_table.sql
@@ -27,5 +27,3 @@ CREATE INDEX idx_queue_scheduled_at ON job_queue(queue, status, scheduled_at, at
 
 -- Needed for UPDATE-ing incomplete jobs with a specific target (i.e. slow destinations)
 CREATE INDEX idx_queue_target ON job_queue(queue, status, target);
-
-SET idle_in_transaction_session_timeout='2min';

--- a/migrations/20240110180056_set_idle_in_transaction_timeout.sql
+++ b/migrations/20240110180056_set_idle_in_transaction_timeout.sql
@@ -1,2 +1,2 @@
 -- If running worker in transactional mode, this ensures we clean up any open transactions.
-SET idle_in_transaction_session_timeout='2min';
+ALTER USER current_user SET idle_in_transaction_session_timeout = '2min';

--- a/migrations/20240110180056_set_idle_in_transaction_timeout.sql
+++ b/migrations/20240110180056_set_idle_in_transaction_timeout.sql
@@ -1,0 +1,2 @@
+-- If running worker in transactional mode, this ensures we clean up any open transactions.
+SET idle_in_transaction_session_timeout='2min';


### PR DESCRIPTION
This [setting](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT) is disabled by default. We rely on it to clean up things on transactional mode, so let's set it in a migration.