### PR TITLE
Remove idle_in_transaction_session_timeout migration

### DIFF
--- a/migrations/20240110180056_set_idle_in_transaction_timeout.sql
+++ b/migrations/20240110180056_set_idle_in_transaction_timeout.sql
@@ -1,2 +1,0 @@
--- If running worker in transactional mode, this ensures we clean up any open transactions.
-ALTER USER current_user SET idle_in_transaction_session_timeout = '2min';


### PR DESCRIPTION
So because this is ALTERing the user, it races and makes concurrent tests fail with `tuple concurrently updated`.

I tried adding an advisory lock to no avail.

This should change it in the DB: https://github.com/PostHog/posthog-cloud-infra/pull/2433