### PR TITLE
Use signed integers for plugin_id/plugin_config_id

### DIFF
--- a/hook-common/src/kafka_messages/app_metrics.rs
+++ b/hook-common/src/kafka_messages/app_metrics.rs
@@ -51,7 +51,7 @@ pub struct AppMetric {
     )]
     pub timestamp: DateTime<Utc>,
     pub team_id: u32,
-    pub plugin_config_id: u32,
+    pub plugin_config_id: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub job_id: Option<String>,
     #[serde(

--- a/hook-common/src/kafka_messages/plugin_logs.rs
+++ b/hook-common/src/kafka_messages/plugin_logs.rs
@@ -30,8 +30,8 @@ pub struct PluginLogEntry {
     pub type_: PluginLogEntryType,
     pub id: Uuid,
     pub team_id: u32,
-    pub plugin_id: u32,
-    pub plugin_config_id: u32,
+    pub plugin_id: i32,
+    pub plugin_config_id: i32,
     #[serde(serialize_with = "serialize_datetime")]
     pub timestamp: DateTime<Utc>,
     #[serde(serialize_with = "serialize_message")]

--- a/hook-common/src/pgqueue.rs
+++ b/hook-common/src/pgqueue.rs
@@ -731,8 +731,8 @@ mod tests {
     #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
     struct JobMetadata {
         team_id: u32,
-        plugin_config_id: u32,
-        plugin_id: u32,
+        plugin_config_id: i32,
+        plugin_id: i32,
     }
 
     impl Default for JobMetadata {

--- a/hook-common/src/webhook.rs
+++ b/hook-common/src/webhook.rs
@@ -133,8 +133,8 @@ pub struct WebhookJobParameters {
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 pub struct WebhookJobMetadata {
     pub team_id: u32,
-    pub plugin_id: u32,
-    pub plugin_config_id: u32,
+    pub plugin_id: i32,
+    pub plugin_config_id: i32,
 }
 
 /// An error originating during a Webhook Job invocation.

--- a/hook-janitor/src/webhooks.rs
+++ b/hook-janitor/src/webhooks.rs
@@ -66,7 +66,7 @@ struct CompletedRow {
     #[sqlx(try_from = "i64")]
     team_id: u32,
     #[sqlx(try_from = "i64")]
-    plugin_config_id: u32,
+    plugin_config_id: i32,
     #[sqlx(try_from = "i64")]
     successes: u32,
 }
@@ -100,7 +100,7 @@ struct FailedRow {
     #[sqlx(try_from = "i64")]
     team_id: u32,
     #[sqlx(try_from = "i64")]
-    plugin_config_id: u32,
+    plugin_config_id: i32,
     #[sqlx(json)]
     last_error: WebhookJobError,
     #[sqlx(try_from = "i64")]


### PR DESCRIPTION
The plan is to use sentinel values -1 and -2 (and maybe others in the future) for fake "plugins" for things like Webhooks that are sent by Action integrations, and not real plugins.

https://posthog.slack.com/archives/C066YCDAWG2/p1705010221524319?thread_ts=1705007769.632829&cid=C066YCDAWG2