### PR TITLE
feat: make sure metrics cover all axum endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,7 @@ dependencies = [
 name = "hook-worker"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "chrono",
  "envconfig",
  "futures",

--- a/hook-api/src/main.rs
+++ b/hook-api/src/main.rs
@@ -3,7 +3,7 @@ use config::Config;
 use envconfig::Envconfig;
 use eyre::Result;
 
-use hook_common::metrics::setup_metrics_router;
+use hook_common::metrics::{setup_metrics_routes};
 use hook_common::pgqueue::PgQueue;
 
 mod config;
@@ -32,8 +32,8 @@ async fn main() {
     .await
     .expect("failed to initialize queue");
 
-    let router = setup_metrics_router();
-    let app = handlers::add_routes(router, pg_queue);
+    let app = handlers::add_routes(Router::new(), pg_queue);
+    let app = setup_metrics_routes(app);
 
     match listen(app, config.bind()).await {
         Ok(_) => {}

--- a/hook-api/src/main.rs
+++ b/hook-api/src/main.rs
@@ -3,7 +3,7 @@ use config::Config;
 use envconfig::Envconfig;
 use eyre::Result;
 
-use hook_common::metrics::{setup_metrics_routes};
+use hook_common::metrics::setup_metrics_routes;
 use hook_common::pgqueue::PgQueue;
 
 mod config;

--- a/hook-common/src/metrics.rs
+++ b/hook-common/src/metrics.rs
@@ -16,11 +16,11 @@ pub async fn serve(router: Router, bind: &str) -> Result<(), std::io::Error> {
     Ok(())
 }
 
-/// Build a Router for a metrics endpoint.
-pub fn setup_metrics_router() -> Router {
+/// Add the prometheus endpoint and middleware to a router, should be called last.
+pub fn setup_metrics_routes(router: Router) -> Router {
     let recorder_handle = setup_metrics_recorder();
 
-    Router::new()
+    router
         .route(
             "/metrics",
             get(move || std::future::ready(recorder_handle.render())),

--- a/hook-janitor/src/handlers/app.rs
+++ b/hook-janitor/src/handlers/app.rs
@@ -1,8 +1,7 @@
 use axum::{routing, Router};
 
 pub fn app() -> Router {
-    Router::new()
-        .route("/", routing::get(index))
+    Router::new().route("/", routing::get(index))
 }
 
 pub async fn index() -> &'static str {

--- a/hook-janitor/src/handlers/app.rs
+++ b/hook-janitor/src/handlers/app.rs
@@ -1,19 +1,8 @@
 use axum::{routing, Router};
-use metrics_exporter_prometheus::PrometheusHandle;
 
-use hook_common::metrics;
-
-pub fn app(metrics: Option<PrometheusHandle>) -> Router {
+pub fn app() -> Router {
     Router::new()
         .route("/", routing::get(index))
-        .route(
-            "/metrics",
-            routing::get(move || match metrics {
-                Some(ref recorder_handle) => std::future::ready(recorder_handle.render()),
-                None => std::future::ready("no metrics recorder installed".to_owned()),
-            }),
-        )
-        .layer(axum::middleware::from_fn(metrics::track_metrics))
 }
 
 pub async fn index() -> &'static str {

--- a/hook-janitor/src/main.rs
+++ b/hook-janitor/src/main.rs
@@ -9,7 +9,7 @@ use std::{str::FromStr, time::Duration};
 use tokio::sync::Semaphore;
 use webhooks::WebhookCleaner;
 
-use hook_common::metrics;
+use hook_common::metrics::setup_metrics_routes;
 
 mod cleanup;
 mod config;
@@ -66,8 +66,7 @@ async fn main() {
 
     let cleanup_loop = Box::pin(cleanup_loop(cleaner, config.cleanup_interval_secs));
 
-    let recorder_handle = metrics::setup_metrics_recorder();
-    let app = handlers::app(Some(recorder_handle));
+    let app = setup_metrics_routes(handlers::app());
     let http_server = Box::pin(listen(app, config.bind()));
 
     match select(http_server, cleanup_loop).await {

--- a/hook-worker/Cargo.toml
+++ b/hook-worker/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+axum = { workspace = true }
 chrono = { workspace = true }
 envconfig = { workspace = true }
 futures = "0.3"

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -1,8 +1,9 @@
 //! Consume `PgQueue` jobs to run webhook calls.
+use axum::Router;
 use envconfig::Envconfig;
 
 use hook_common::{
-    metrics::serve, metrics::setup_metrics_router, pgqueue::PgQueue, retry::RetryPolicy,
+    metrics::serve, metrics::setup_metrics_routes, pgqueue::PgQueue, retry::RetryPolicy,
 };
 use hook_worker::config::Config;
 use hook_worker::error::WorkerError;
@@ -36,7 +37,7 @@ async fn main() -> Result<(), WorkerError> {
 
     let bind = config.bind();
     tokio::task::spawn(async move {
-        let router = setup_metrics_router();
+        let router = setup_metrics_routes(Router::new());
         serve(router, &bind)
             .await
             .expect("failed to start serving metrics");


### PR DESCRIPTION
`hooks-api` does not currently export metrics for the `/webhook` endpoint, as the layer is added to the router before this endpoint:

- Change `setup_metrics_router` into `setup_metrics_routes` that is called with the `Router` already setup with routes to report metrics on
- Change the three roles to use this changed signature