### PR TITLE
feat: add readiness and liveness endpoints to all roles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror",
+ "time",
  "tokio",
  "tower",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,7 +802,9 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror",
+ "time",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -1541,6 +1552,12 @@ name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2312,6 +2329,24 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+dependencies = [
+ "deranged",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "tinyvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,6 +851,7 @@ dependencies = [
  "serde_derive",
  "sqlx",
  "thiserror",
+ "time",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ sqlx = { version = "0.7", features = [
   "tls-native-tls",
   "uuid",
 ] }
+time = { version = "0.3.20" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.34.0", features = ["full"] }
 tower = "0.4.13"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         depends_on:
             db:
                 condition: service_healthy
-                #restart: true
+                restart: true
         environment:
             DATABASE_URL: postgres://posthog:posthog@db:5432/test_database
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         depends_on:
             db:
                 condition: service_healthy
-                restart: true
+                #restart: true
         environment:
             DATABASE_URL: postgres://posthog:posthog@db:5432/test_database
 

--- a/hook-api/src/handlers/app.rs
+++ b/hook-api/src/handlers/app.rs
@@ -7,6 +7,8 @@ use super::webhook;
 pub fn add_routes(router: Router, pg_pool: PgQueue) -> Router {
     router
         .route("/", routing::get(index))
+        .route("/_readiness", routing::get(index))
+        .route("/_liveness", routing::get(index)) // No async loop for now, just check axum health
         .route("/webhook", routing::post(webhook::post).with_state(pg_pool))
 }
 

--- a/hook-common/Cargo.toml
+++ b/hook-common/Cargo.toml
@@ -18,8 +18,10 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
+time = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/hook-common/src/health.rs
+++ b/hook-common/src/health.rs
@@ -1,0 +1,346 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use std::collections::HashMap;
+use std::ops::Add;
+use std::sync::{Arc, RwLock};
+
+use time::Duration;
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+/// Health reporting for components of the service.
+///
+/// FIXME: copied over from capture, make sure to keep in sync until we share the crate
+///
+/// The capture server contains several asynchronous loops, and
+/// the process can only be trusted with user data if all the
+/// loops are properly running and reporting.
+///
+/// HealthRegistry allows an arbitrary number of components to
+/// be registered and report their health. The process' health
+/// status is the combination of these individual health status:
+///   - if any component is unhealthy, the process is unhealthy
+///   - if all components recently reported healthy, the process is healthy
+///   - if a component failed to report healthy for its defined deadline,
+///     it is considered unhealthy, and the check fails.
+///
+/// Trying to merge the k8s concepts of liveness and readiness in
+/// a single state is full of foot-guns, so HealthRegistry does not
+/// try to do it. Each probe should have its separate instance of
+/// the registry to avoid confusions.
+
+#[derive(Default, Debug)]
+pub struct HealthStatus {
+    /// The overall status: true of all components are healthy
+    pub healthy: bool,
+    /// Current status of each registered component, for display
+    pub components: HashMap<String, ComponentStatus>,
+}
+impl IntoResponse for HealthStatus {
+    /// Computes the axum status code based on the overall health status,
+    /// and prints each component status in the body for debugging.
+    fn into_response(self) -> Response {
+        let body = format!("{:?}", self);
+        match self.healthy {
+            true => (StatusCode::OK, body),
+            false => (StatusCode::INTERNAL_SERVER_ERROR, body),
+        }
+        .into_response()
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ComponentStatus {
+    /// Automatically set when a component is newly registered
+    Starting,
+    /// Recently reported healthy, will need to report again before the date
+    HealthyUntil(time::OffsetDateTime),
+    /// Reported unhealthy
+    Unhealthy,
+    /// Automatically set when the HealthyUntil deadline is reached
+    Stalled,
+}
+struct HealthMessage {
+    component: String,
+    status: ComponentStatus,
+}
+
+pub struct HealthHandle {
+    component: String,
+    deadline: Duration,
+    sender: mpsc::Sender<HealthMessage>,
+}
+
+impl HealthHandle {
+    /// Asynchronously report healthy, returns when the message is queued.
+    /// Must be called more frequently than the configured deadline.
+    pub async fn report_healthy(&self) {
+        self.report_status(ComponentStatus::HealthyUntil(
+            time::OffsetDateTime::now_utc().add(self.deadline),
+        ))
+        .await
+    }
+
+    /// Asynchronously report component status, returns when the message is queued.
+    pub async fn report_status(&self, status: ComponentStatus) {
+        let message = HealthMessage {
+            component: self.component.clone(),
+            status,
+        };
+        if let Err(err) = self.sender.send(message).await {
+            warn!("failed to report heath status: {}", err)
+        }
+    }
+
+    /// Synchronously report as healthy, returns when the message is queued.
+    /// Must be called more frequently than the configured deadline.
+    pub fn report_healthy_blocking(&self) {
+        self.report_status_blocking(ComponentStatus::HealthyUntil(
+            time::OffsetDateTime::now_utc().add(self.deadline),
+        ))
+    }
+
+    /// Asynchronously report component status, returns when the message is queued.
+    pub fn report_status_blocking(&self, status: ComponentStatus) {
+        let message = HealthMessage {
+            component: self.component.clone(),
+            status,
+        };
+        if let Err(err) = self.sender.blocking_send(message) {
+            warn!("failed to report heath status: {}", err)
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HealthRegistry {
+    name: String,
+    components: Arc<RwLock<HashMap<String, ComponentStatus>>>,
+    sender: mpsc::Sender<HealthMessage>,
+}
+
+impl HealthRegistry {
+    pub fn new(name: &str) -> Self {
+        let (tx, mut rx) = mpsc::channel::<HealthMessage>(16);
+        let registry = Self {
+            name: name.to_owned(),
+            components: Default::default(),
+            sender: tx,
+        };
+
+        let components = registry.components.clone();
+        tokio::spawn(async move {
+            while let Some(message) = rx.recv().await {
+                if let Ok(mut map) = components.write() {
+                    _ = map.insert(message.component, message.status);
+                } else {
+                    // Poisoned mutex: Just warn, the probes will fail and the process restart
+                    warn!("poisoned HeathRegistry mutex")
+                }
+            }
+        });
+
+        registry
+    }
+
+    /// Registers a new component in the registry. The returned handle should be passed
+    /// to the component, to allow it to frequently report its health status.
+    pub async fn register(&self, component: String, deadline: time::Duration) -> HealthHandle {
+        let handle = HealthHandle {
+            component,
+            deadline,
+            sender: self.sender.clone(),
+        };
+        handle.report_status(ComponentStatus::Starting).await;
+        handle
+    }
+
+    /// Returns the overall process status, computed from the status of all the components
+    /// currently registered. Can be used as an axum handler.
+    pub fn get_status(&self) -> HealthStatus {
+        let components = self
+            .components
+            .read()
+            .expect("poisoned HeathRegistry mutex");
+
+        let result = HealthStatus {
+            healthy: !components.is_empty(), // unhealthy if no component has registered yet
+            components: Default::default(),
+        };
+        let now = time::OffsetDateTime::now_utc();
+
+        let result = components
+            .iter()
+            .fold(result, |mut result, (name, status)| {
+                match status {
+                    ComponentStatus::HealthyUntil(until) => {
+                        if until.gt(&now) {
+                            _ = result.components.insert(name.clone(), status.clone())
+                        } else {
+                            result.healthy = false;
+                            _ = result
+                                .components
+                                .insert(name.clone(), ComponentStatus::Stalled)
+                        }
+                    }
+                    _ => {
+                        result.healthy = false;
+                        _ = result.components.insert(name.clone(), status.clone())
+                    }
+                }
+                result
+            });
+        match result.healthy {
+            true => info!("{} health check ok", self.name),
+            false => warn!("{} health check failed: {:?}", self.name, result.components),
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::health::{ComponentStatus, HealthRegistry, HealthStatus};
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use std::ops::{Add, Sub};
+    use time::{Duration, OffsetDateTime};
+
+    async fn assert_or_retry<F>(check: F)
+    where
+        F: Fn() -> bool,
+    {
+        assert_or_retry_for_duration(check, Duration::seconds(5)).await
+    }
+
+    async fn assert_or_retry_for_duration<F>(check: F, timeout: Duration)
+    where
+        F: Fn() -> bool,
+    {
+        let deadline = OffsetDateTime::now_utc().add(timeout);
+        while !check() && OffsetDateTime::now_utc().lt(&deadline) {
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+        assert!(check())
+    }
+    #[tokio::test]
+    async fn defaults_to_unhealthy() {
+        let registry = HealthRegistry::new("liveness");
+        assert!(!registry.get_status().healthy);
+    }
+
+    #[tokio::test]
+    async fn one_component() {
+        let registry = HealthRegistry::new("liveness");
+
+        // New components are registered in Starting
+        let handle = registry
+            .register("one".to_string(), Duration::seconds(30))
+            .await;
+        assert_or_retry(|| registry.get_status().components.len() == 1).await;
+        let mut status = registry.get_status();
+        assert!(!status.healthy);
+        assert_eq!(
+            status.components.get("one"),
+            Some(&ComponentStatus::Starting)
+        );
+
+        // Status goes healthy once the component reports
+        handle.report_healthy().await;
+        assert_or_retry(|| registry.get_status().healthy).await;
+        status = registry.get_status();
+        assert_eq!(status.components.len(), 1);
+
+        // Status goes unhealthy if the components says so
+        handle.report_status(ComponentStatus::Unhealthy).await;
+        assert_or_retry(|| !registry.get_status().healthy).await;
+        status = registry.get_status();
+        assert_eq!(status.components.len(), 1);
+        assert_eq!(
+            status.components.get("one"),
+            Some(&ComponentStatus::Unhealthy)
+        );
+    }
+
+    #[tokio::test]
+    async fn staleness_check() {
+        let registry = HealthRegistry::new("liveness");
+        let handle = registry
+            .register("one".to_string(), Duration::seconds(30))
+            .await;
+
+        // Status goes healthy once the component reports
+        handle.report_healthy().await;
+        assert_or_retry(|| registry.get_status().healthy).await;
+        let mut status = registry.get_status();
+        assert_eq!(status.components.len(), 1);
+
+        // If the component's ping is too old, it is considered stalled and the healthcheck fails
+        // FIXME: we should mock the time instead
+        handle
+            .report_status(ComponentStatus::HealthyUntil(
+                OffsetDateTime::now_utc().sub(Duration::seconds(1)),
+            ))
+            .await;
+        assert_or_retry(|| !registry.get_status().healthy).await;
+        status = registry.get_status();
+        assert_eq!(status.components.len(), 1);
+        assert_eq!(
+            status.components.get("one"),
+            Some(&ComponentStatus::Stalled)
+        );
+    }
+
+    #[tokio::test]
+    async fn several_components() {
+        let registry = HealthRegistry::new("liveness");
+        let handle1 = registry
+            .register("one".to_string(), Duration::seconds(30))
+            .await;
+        let handle2 = registry
+            .register("two".to_string(), Duration::seconds(30))
+            .await;
+        assert_or_retry(|| registry.get_status().components.len() == 2).await;
+
+        // First component going healthy is not enough
+        handle1.report_healthy().await;
+        assert_or_retry(|| {
+            registry.get_status().components.get("one").unwrap() != &ComponentStatus::Starting
+        })
+        .await;
+        assert!(!registry.get_status().healthy);
+
+        // Second component going healthy brings the health to green
+        handle2.report_healthy().await;
+        assert_or_retry(|| {
+            registry.get_status().components.get("two").unwrap() != &ComponentStatus::Starting
+        })
+        .await;
+        assert!(registry.get_status().healthy);
+
+        // First component going unhealthy takes down the health to red
+        handle1.report_status(ComponentStatus::Unhealthy).await;
+        assert_or_retry(|| !registry.get_status().healthy).await;
+
+        // First component recovering returns the health to green
+        handle1.report_healthy().await;
+        assert_or_retry(|| registry.get_status().healthy).await;
+
+        // Second component going unhealthy takes down the health to red
+        handle2.report_status(ComponentStatus::Unhealthy).await;
+        assert_or_retry(|| !registry.get_status().healthy).await;
+    }
+
+    #[tokio::test]
+    async fn into_response() {
+        let nok = HealthStatus::default().into_response();
+        assert_eq!(nok.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let ok = HealthStatus {
+            healthy: true,
+            components: Default::default(),
+        }
+        .into_response();
+        assert_eq!(ok.status(), StatusCode::OK);
+    }
+}

--- a/hook-common/src/lib.rs
+++ b/hook-common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod health;
 pub mod kafka_messages;
 pub mod metrics;
 pub mod pgqueue;

--- a/hook-janitor/Cargo.toml
+++ b/hook-janitor/Cargo.toml
@@ -20,6 +20,7 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
+time = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/hook-janitor/src/handlers/app.rs
+++ b/hook-janitor/src/handlers/app.rs
@@ -1,7 +1,12 @@
-use axum::{routing, Router};
+use axum::{routing::get, Router};
+use hook_common::health::HealthRegistry;
+use std::future::ready;
 
-pub fn app() -> Router {
-    Router::new().route("/", routing::get(index))
+pub fn app(liveness: HealthRegistry) -> Router {
+    Router::new()
+        .route("/", get(index))
+        .route("/_readiness", get(index))
+        .route("/_liveness", get(move || ready(liveness.get_status())))
 }
 
 pub async fn index() -> &'static str {

--- a/hook-janitor/src/kafka_producer.rs
+++ b/hook-janitor/src/kafka_producer.rs
@@ -1,17 +1,27 @@
 use crate::config::KafkaConfig;
 
+use hook_common::health::HealthHandle;
 use rdkafka::error::KafkaError;
 use rdkafka::producer::FutureProducer;
 use rdkafka::ClientConfig;
 use tracing::debug;
 
-// TODO: Take stats recording pieces that we want from `capture-rs`.
-pub struct KafkaContext {}
+pub struct KafkaContext {
+    liveness: HealthHandle,
+}
 
-impl rdkafka::ClientContext for KafkaContext {}
+impl rdkafka::ClientContext for KafkaContext {
+    fn stats(&self, _: rdkafka::Statistics) {
+        // Signal liveness, as the main rdkafka loop is running and calling us
+        self.liveness.report_healthy_blocking();
+
+        // TODO: Take stats recording pieces that we want from `capture-rs`.
+    }
+}
 
 pub async fn create_kafka_producer(
     config: &KafkaConfig,
+    liveness: HealthHandle,
 ) -> Result<FutureProducer<KafkaContext>, KafkaError> {
     let mut client_config = ClientConfig::new();
     client_config
@@ -38,7 +48,10 @@ pub async fn create_kafka_producer(
     };
 
     debug!("rdkafka configuration: {:?}", client_config);
-    let api: FutureProducer<KafkaContext> = client_config.create_with_context(KafkaContext {})?;
+    let api: FutureProducer<KafkaContext> =
+        client_config.create_with_context(KafkaContext { liveness })?;
+
+    // TODO: ping the kafka browkers to confirm configuration is OK (copy capture)
 
     Ok(api)
 }

--- a/hook-janitor/src/kafka_producer.rs
+++ b/hook-janitor/src/kafka_producer.rs
@@ -51,7 +51,7 @@ pub async fn create_kafka_producer(
     let api: FutureProducer<KafkaContext> =
         client_config.create_with_context(KafkaContext { liveness })?;
 
-    // TODO: ping the kafka browkers to confirm configuration is OK (copy capture)
+    // TODO: ping the kafka brokers to confirm configuration is OK (copy capture)
 
     Ok(api)
 }

--- a/hook-worker/Cargo.toml
+++ b/hook-worker/Cargo.toml
@@ -15,6 +15,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 sqlx = { workspace = true }
+time = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -1,7 +1,10 @@
 //! Consume `PgQueue` jobs to run webhook calls.
+use axum::routing::get;
 use axum::Router;
 use envconfig::Envconfig;
+use std::future::ready;
 
+use hook_common::health::HealthRegistry;
 use hook_common::{
     metrics::serve, metrics::setup_metrics_routes, pgqueue::PgQueue, retry::RetryPolicy,
 };
@@ -14,6 +17,11 @@ async fn main() -> Result<(), WorkerError> {
     tracing_subscriber::fmt::init();
 
     let config = Config::init_from_env().expect("Invalid configuration:");
+
+    let liveness = HealthRegistry::new("liveness");
+    let worker_liveness = liveness
+        .register("worker".to_string(), time::Duration::seconds(60)) // TODO: compute the value from worker params
+        .await;
 
     let retry_policy = RetryPolicy::build(
         config.retry_policy.backoff_coefficient,
@@ -35,15 +43,23 @@ async fn main() -> Result<(), WorkerError> {
         retry_policy,
     );
 
+    let router = Router::new()
+        .route("/", get(index))
+        .route("/_readiness", get(index))
+        .route("/_liveness", get(move || ready(liveness.get_status())));
+    let router = setup_metrics_routes(router);
     let bind = config.bind();
     tokio::task::spawn(async move {
-        let router = setup_metrics_routes(Router::new());
         serve(router, &bind)
             .await
             .expect("failed to start serving metrics");
     });
 
-    worker.run(config.transactional).await?;
+    worker.run(config.transactional, worker_liveness).await?;
 
     Ok(())
+}
+
+pub async fn index() -> &'static str {
+    "rusty-hook worker"
 }

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -41,6 +41,7 @@ async fn main() -> Result<(), WorkerError> {
         config.request_timeout.0,
         config.max_concurrent_jobs,
         retry_policy,
+        worker_liveness,
     );
 
     let router = Router::new()
@@ -55,7 +56,7 @@ async fn main() -> Result<(), WorkerError> {
             .expect("failed to start serving metrics");
     });
 
-    worker.run(config.transactional, worker_liveness).await?;
+    worker.run(config.transactional).await?;
 
     Ok(())
 }


### PR DESCRIPTION
In my experience, it’s better not to fail liveness or readiness on missing dependencies, because restarting pods is less information than proper http errors / error logs. This PR mirrors capture’s behaviour:

- having all readiness probes to a simple index endpoint: axum is started last, and the pod should be ready to accept requests as soon as axum is ready
- monitor the long-lived async loops (janitor loop, worker loop, rdkafka producer) on the liveness: if they stop / hang for too long, the process will be restarted. For api, there’s currently no background loop, so liveness = index for now

For simplicity, I'm copying `health.rs` over from capture-rs, we should:
  - rework its api to not depend on the `time` crate
  - share the crate between the codebases


## Tests:

Janitor:
```
$ curl localhost:3302/_readiness
rusty-hook janitor
$ curl localhost:3302/_liveness
HealthStatus { healthy: true, components: {"cleanup_loop": HealthyUntil(2024-01-16 16:07:54.088147 +00:00:00), "rdkafka": HealthyUntil(2024-01-16 16:07:24.087438 +00:00:00)} }
```

Worker:
```
$ curl localhost:3301/_readiness
rusty-hook worker
$ curl localhost:3301/_liveness
HealthStatus { healthy: true, components: {"worker": HealthyUntil(2024-01-16 16:09:22.245115 +00:00:00)} }
```

API: 
```
$ curl localhost:3300/_readiness
rusty-hook api
$ curl localhost:3300/_liveness
rusty-hook api
```