### PR TITLE
Log error rather than exiting process on dequeue error

### DIFF
--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), WorkerError> {
             .expect("failed to start serving metrics");
     });
 
-    worker.run(config.transactional).await?;
+    worker.run(config.transactional).await;
 
     Ok(())
 }


### PR DESCRIPTION
@xvello and I were talking, and it seems better to log an error and retry if PG has a hiccup. Crashing and restarting the pod is pretty expensive, and monitoring should catch if we aren't making progress on the queue.