### PR TITLE
Make retry_queue_name truly optional from env to main

### DIFF
--- a/hook-janitor/src/webhooks.rs
+++ b/hook-janitor/src/webhooks.rs
@@ -752,13 +752,9 @@ mod tests {
             .expect("failed to create mock consumer");
         consumer.subscribe(&[APP_METRICS_TOPIC]).unwrap();
 
-        let webhook_cleaner = WebhookCleaner::new_from_pool(
-            &"webhooks",
-            db,
-            mock_producer,
-            APP_METRICS_TOPIC.to_owned(),
-        )
-        .expect("unable to create webhook cleaner");
+        let webhook_cleaner =
+            WebhookCleaner::new_from_pool(db, mock_producer, APP_METRICS_TOPIC.to_owned())
+                .expect("unable to create webhook cleaner");
 
         let cleanup_stats = webhook_cleaner
             .cleanup_impl()

--- a/hook-worker/src/config.rs
+++ b/hook-worker/src/config.rs
@@ -70,6 +70,5 @@ pub struct RetryPolicyConfig {
     #[envconfig(default = "100000")]
     pub maximum_interval: EnvMsDuration,
 
-    #[envconfig(default = "default")]
-    pub retry_queue_name: String,
+    pub retry_queue_name: Option<String>,
 }

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -23,13 +23,13 @@ async fn main() -> Result<(), WorkerError> {
         .register("worker".to_string(), time::Duration::seconds(60)) // TODO: compute the value from worker params
         .await;
 
-    let retry_policy_builder = RetryPolicy::build(
+    let mut retry_policy_builder = RetryPolicy::build(
         config.retry_policy.backoff_coefficient,
         config.retry_policy.initial_interval.0,
     )
     .maximum_interval(config.retry_policy.maximum_interval.0);
 
-    let retry_policy_builder = match &config.retry_policy.retry_queue_name {
+    retry_policy_builder = match &config.retry_policy.retry_queue_name {
         Some(retry_queue_name) if !retry_queue_name.is_empty() => {
             retry_policy_builder.queue(retry_queue_name)
         }

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -30,9 +30,7 @@ async fn main() -> Result<(), WorkerError> {
     .maximum_interval(config.retry_policy.maximum_interval.0);
 
     retry_policy_builder = match &config.retry_policy.retry_queue_name {
-        Some(retry_queue_name) if !retry_queue_name.is_empty() => {
-            retry_policy_builder.queue(retry_queue_name)
-        }
+        Some(retry_queue_name) => retry_policy_builder.queue(retry_queue_name),
         _ => retry_policy_builder,
     };
 

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -30,8 +30,10 @@ async fn main() -> Result<(), WorkerError> {
     .maximum_interval(config.retry_policy.maximum_interval.0);
 
     let retry_policy_builder = match &config.retry_policy.retry_queue_name {
-        Some(retry_queue_name) => retry_policy_builder.queue(retry_queue_name),
-        None => retry_policy_builder,
+        Some(retry_queue_name) if !retry_queue_name.is_empty() => {
+            retry_policy_builder.queue(retry_queue_name)
+        }
+        _ => retry_policy_builder,
     };
 
     let queue = PgQueue::new(&config.queue_name, &config.database_url)


### PR DESCRIPTION
This was setting our retry queue to `default` when we don't set it, which would have been confusing.