### PR TITLE
fix: fix janitor get_queue_depth when queue is empty

### DIFF
--- a/hook-janitor/src/webhooks.rs
+++ b/hook-janitor/src/webhooks.rs
@@ -195,9 +195,9 @@ impl WebhookCleaner {
         let base_query = r#"
         SELECT
             COALESCE(MIN(CASE WHEN attempt = 0 THEN created_at END), now()) AS oldest_created_at_untried,
-            SUM(CASE WHEN attempt = 0 THEN 1 ELSE 0 END) AS count_untried,
+            COALESCE(SUM(CASE WHEN attempt = 0 THEN 1 ELSE 0 END), 0) AS count_untried,
             COALESCE(MIN(CASE WHEN attempt > 0 THEN created_at END), now()) AS oldest_created_at_retries,
-            SUM(CASE WHEN attempt > 0 THEN 1 ELSE 0 END) AS count_retries
+            COALESCE(SUM(CASE WHEN attempt > 0 THEN 1 ELSE 0 END), 0) AS count_retries
         FROM job_queue
         WHERE status = 'available'
           AND queue = $1;


### PR DESCRIPTION
Janitor currently fails on an empty queue with:

> 2024-01-17T10:33:38.342667Z ERROR hook_janitor::webhooks: WebhookCleaner::cleanup failed error=GetQueueDepthError { error: ColumnDecode { index: "\"count_untried\"", source: UnexpectedNullError } }

Coalesce a zero to avoid returning a null to rust