### PR TITLE
 refactor: Use new NonEmptyString config type  for queue names

### DIFF
--- a/hook-worker/src/config.rs
+++ b/hook-worker/src/config.rs
@@ -18,7 +18,7 @@ pub struct Config {
     pub worker_name: String,
 
     #[envconfig(default = "default")]
-    pub queue_name: String,
+    pub queue_name: NonEmptyString,
 
     #[envconfig(default = "100")]
     pub poll_interval: EnvMsDuration,
@@ -70,5 +70,29 @@ pub struct RetryPolicyConfig {
     #[envconfig(default = "100000")]
     pub maximum_interval: EnvMsDuration,
 
-    pub retry_queue_name: Option<String>,
+    pub retry_queue_name: Option<NonEmptyString>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NonEmptyString(pub String);
+
+impl NonEmptyString {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct StringIsEmptyError;
+
+impl FromStr for NonEmptyString {
+    type Err = StringIsEmptyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            Err(StringIsEmptyError)
+        } else {
+            Ok(NonEmptyString(s.to_owned()))
+        }
+    }
 }

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -29,12 +29,13 @@ async fn main() -> Result<(), WorkerError> {
     )
     .maximum_interval(config.retry_policy.maximum_interval.0);
 
-    retry_policy_builder = match &config.retry_policy.retry_queue_name {
-        Some(retry_queue_name) => retry_policy_builder.queue(retry_queue_name),
-        _ => retry_policy_builder,
+    retry_policy_builder = if let Some(retry_queue_name) = &config.retry_policy.retry_queue_name {
+        retry_policy_builder.queue(retry_queue_name.as_str())
+    } else {
+        retry_policy_builder
     };
 
-    let queue = PgQueue::new(&config.queue_name, &config.database_url)
+    let queue = PgQueue::new(config.queue_name.as_str(), &config.database_url)
         .await
         .expect("failed to initialize queue");
 


### PR DESCRIPTION
Looks a bit cleaner and now `RETRY_QUEUE_NAME` and `QUEUE_NAME` are consistent, but not super necessary.