### PR TITLE
Dequeue multiple items at a time (to a configured limit)

### DIFF
--- a/hook-janitor/src/webhooks.rs
+++ b/hook-janitor/src/webhooks.rs
@@ -810,7 +810,7 @@ mod tests {
         {
             // The fixtures include an available job, so let's complete it while the txn is open.
             let webhook_job: PgJob<WebhookJobParameters, WebhookJobMetadata> = queue
-                .dequeue(&"worker_id")
+                .dequeue_one(&"worker_id")
                 .await
                 .expect("failed to dequeue job")
                 .expect("didn't find a job to dequeue");
@@ -836,7 +836,7 @@ mod tests {
             let new_job = NewJob::new(1, job_metadata, job_parameters, &"target");
             queue.enqueue(new_job).await.expect("failed to enqueue job");
             let webhook_job: PgJob<WebhookJobParameters, WebhookJobMetadata> = queue
-                .dequeue(&"worker_id")
+                .dequeue_one(&"worker_id")
                 .await
                 .expect("failed to dequeue job")
                 .expect("didn't find a job to dequeue");

--- a/hook-worker/src/config.rs
+++ b/hook-worker/src/config.rs
@@ -34,6 +34,9 @@ pub struct Config {
 
     #[envconfig(default = "true")]
     pub transactional: bool,
+
+    #[envconfig(default = "10")]
+    pub dequeue_count: u32,
 }
 
 impl Config {

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -42,6 +42,7 @@ async fn main() -> Result<(), WorkerError> {
     let worker = WebhookWorker::new(
         &config.worker_name,
         &queue,
+        config.dequeue_count,
         config.poll_interval.0,
         config.request_timeout.0,
         config.max_concurrent_jobs,


### PR DESCRIPTION
The dequeue query is especially expensive if we're just plucking out one row.

For the non-transactional implementation this is easy, just return more than 1, and acquire connections as needed to update to the DB after jobs run.

For the transactional implementation, we need to share the txn and only commit when all jobs are done (even if they failed, that's fine). I tried a number of ways, and am going to take a break and get some 👀 before I look at this any more.

---

What I have works, but it's a little ugly. I've been struggling to find a clean way to test it (I'd like to break the txn in the middle and prove things work). The happy path works fine.

Why not `commit` in `impl Drop`?
1. You can't call async code in Drop, and commit is async.
2. We don't want to block the event loop in drop to get around that.
3. You can't move something with a non-static lifetime (the transaction) into an async block.

Maybe putting things on a channel would work, but it seemed like even more refactoring and services to manage.

A much larger refactor would be to expose the transaction to the worker. In a perfect world, we'd receive a `Vec` of jobs, run them all in parallel, and just commit at the end of a plain old normal async fn.

Curious for thoughts.