### PR TITLE
add webhook_cleanup_last_success_timestamp metric for alerting

### DIFF
--- a/hook-common/src/metrics.rs
+++ b/hook-common/src/metrics.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Instant, SystemTime};
 
 use axum::{
     body::Body, extract::MatchedPath, http::Request, middleware::Next, response::IntoResponse,
@@ -70,4 +70,13 @@ pub async fn track_metrics(req: Request<Body>, next: Next) -> impl IntoResponse 
     metrics::histogram!("http_requests_duration_seconds", &labels).record(latency);
 
     response
+}
+
+/// Returns the number of seconds since the Unix epoch, to use in prom gauges.
+/// Saturates to zero if the system time is set before epoch.
+pub fn get_current_timestamp_seconds() -> f64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as f64
 }

--- a/hook-janitor/src/webhooks.rs
+++ b/hook-janitor/src/webhooks.rs
@@ -17,6 +17,7 @@ use crate::cleanup::Cleaner;
 use crate::kafka_producer::KafkaContext;
 
 use hook_common::kafka_messages::app_metrics::{AppMetric, AppMetricCategory};
+use hook_common::metrics::get_current_timestamp_seconds;
 
 #[derive(Error, Debug)]
 pub enum WebhookCleanerError {
@@ -446,6 +447,8 @@ impl Cleaner for WebhookCleaner {
         match self.cleanup_impl().await {
             Ok(stats) => {
                 metrics::counter!("webhook_cleanup_success",).increment(1);
+                metrics::gauge!("webhook_cleanup_last_success_timestamp",)
+                    .set(get_current_timestamp_seconds());
 
                 if stats.rows_processed > 0 {
                     let elapsed_time = start_time.elapsed().as_secs_f64();


### PR DESCRIPTION
To address https://github.com/PostHog/charts/pull/673#discussion_r1458063030, what we care about here is whether janitor is falling behind or not, so let's not infer this from the success rate metric, and dedicate a metric to this alert.