### PR TITLE
Dequeue multiple items at a time

### DIFF
--- a/hook-common/src/pgqueue.rs
+++ b/hook-common/src/pgqueue.rs
@@ -30,6 +30,8 @@ pub enum PgQueueError {
 pub enum PgJobError<T> {
     #[error("retry is an invalid state for this PgJob: {error}")]
     RetryInvalidError { job: T, error: String },
+    #[error("connection failed with: {error}")]
+    ConnectionError { error: sqlx::Error },
     #[error("{command} query failed with: {error}")]
     QueryError { command: String, error: sqlx::Error },
     #[error("transaction {command} failed with: {error}")]
@@ -217,20 +219,34 @@ pub trait PgQueueJob {
 #[derive(Debug)]
 pub struct PgJob<J, M> {
     pub job: Job<J, M>,
-    pub connection: sqlx::pool::PoolConnection<sqlx::postgres::Postgres>,
+    pub pool: PgPool,
+}
+
+impl<J: std::marker::Send, M: std::marker::Send> PgJob<J, M> {
+    async fn acquire_conn(
+        &mut self,
+    ) -> Result<sqlx::pool::PoolConnection<sqlx::postgres::Postgres>, PgJobError<Box<PgJob<J, M>>>>
+    {
+        self.pool
+            .acquire()
+            .await
+            .map_err(|error| PgJobError::ConnectionError { error })
+    }
 }
 
 #[async_trait]
 impl<J: std::marker::Send, M: std::marker::Send> PgQueueJob for PgJob<J, M> {
     async fn complete(mut self) -> Result<CompletedJob, PgJobError<Box<PgJob<J, M>>>> {
-        let completed_job = self
-            .job
-            .complete(&mut *self.connection)
-            .await
-            .map_err(|error| PgJobError::QueryError {
-                command: "UPDATE".to_owned(),
-                error,
-            })?;
+        let mut connection = self.acquire_conn().await?;
+
+        let completed_job =
+            self.job
+                .complete(&mut *connection)
+                .await
+                .map_err(|error| PgJobError::QueryError {
+                    command: "UPDATE".to_owned(),
+                    error,
+                })?;
 
         Ok(completed_job)
     }
@@ -239,9 +255,11 @@ impl<J: std::marker::Send, M: std::marker::Send> PgQueueJob for PgJob<J, M> {
         mut self,
         error: E,
     ) -> Result<FailedJob<E>, PgJobError<Box<PgJob<J, M>>>> {
+        let mut connection = self.acquire_conn().await?;
+
         let failed_job = self
             .job
-            .fail(error, &mut *self.connection)
+            .fail(error, &mut *connection)
             .await
             .map_err(|error| PgJobError::QueryError {
                 command: "UPDATE".to_owned(),
@@ -264,11 +282,13 @@ impl<J: std::marker::Send, M: std::marker::Send> PgQueueJob for PgJob<J, M> {
             });
         }
 
+        let mut connection = self.acquire_conn().await?;
+
         let retried_job = self
             .job
             .retryable()
             .queue(queue)
-            .retry(error, retry_interval, &mut *self.connection)
+            .retry(error, retry_interval, &mut *connection)
             .await
             .map_err(|error| PgJobError::QueryError {
                 command: "UPDATE".to_owned(),
@@ -608,7 +628,10 @@ RETURNING
             .await;
 
         match query_result {
-            Ok(job) => Ok(Some(PgJob { job, connection })),
+            Ok(job) => Ok(Some(PgJob {
+                job,
+                pool: self.pool.clone(),
+            })),
 
             // Although connection would be closed once it goes out of scope, sqlx recommends explicitly calling close().
             // See: https://docs.rs/sqlx/latest/sqlx/postgres/any/trait.AnyConnectionBackend.html#tymethod.close.

--- a/hook-janitor/src/webhooks.rs
+++ b/hook-janitor/src/webhooks.rs
@@ -870,10 +870,13 @@ mod tests {
         {
             // The fixtures include an available job, so let's complete it while the txn is open.
             let webhook_job: PgJob<WebhookJobParameters, WebhookJobMetadata> = queue
-                .dequeue(&"worker_id")
+                .dequeue(&"worker_id", 1)
                 .await
                 .expect("failed to dequeue job")
-                .expect("didn't find a job to dequeue");
+                .expect("didn't find a job to dequeue")
+                .jobs
+                .pop()
+                .unwrap();
             webhook_job
                 .complete()
                 .await
@@ -896,10 +899,13 @@ mod tests {
             let new_job = NewJob::new(1, job_metadata, job_parameters, &"target");
             queue.enqueue(new_job).await.expect("failed to enqueue job");
             let webhook_job: PgJob<WebhookJobParameters, WebhookJobMetadata> = queue
-                .dequeue(&"worker_id")
+                .dequeue(&"worker_id", 1)
                 .await
                 .expect("failed to dequeue job")
-                .expect("didn't find a job to dequeue");
+                .expect("didn't find a job to dequeue")
+                .jobs
+                .pop()
+                .unwrap();
             webhook_job
                 .complete()
                 .await

--- a/hook-worker/src/config.rs
+++ b/hook-worker/src/config.rs
@@ -39,7 +39,7 @@ pub struct Config {
     pub transactional: bool,
 
     #[envconfig(default = "10")]
-    pub dequeue_count: u32,
+    pub dequeue_batch_size: u32,
 }
 
 impl Config {

--- a/hook-worker/src/config.rs
+++ b/hook-worker/src/config.rs
@@ -37,6 +37,9 @@ pub struct Config {
 
     #[envconfig(default = "true")]
     pub transactional: bool,
+
+    #[envconfig(default = "10")]
+    pub dequeue_count: u32,
 }
 
 impl Config {

--- a/hook-worker/src/config.rs
+++ b/hook-worker/src/config.rs
@@ -38,7 +38,7 @@ pub struct Config {
     #[envconfig(default = "true")]
     pub transactional: bool,
 
-    #[envconfig(default = "10")]
+    #[envconfig(default = "1")]
     pub dequeue_batch_size: u32,
 }
 

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<(), WorkerError> {
     let worker = WebhookWorker::new(
         &config.worker_name,
         &queue,
-        config.dequeue_count,
+        config.dequeue_batch_size,
         config.poll_interval.0,
         config.request_timeout.0,
         config.max_concurrent_jobs,

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -47,6 +47,7 @@ async fn main() -> Result<(), WorkerError> {
     let worker = WebhookWorker::new(
         &config.worker_name,
         &queue,
+        config.dequeue_count,
         config.poll_interval.0,
         config.request_timeout.0,
         config.max_concurrent_jobs,

--- a/hook-worker/src/worker.rs
+++ b/hook-worker/src/worker.rs
@@ -182,6 +182,10 @@ impl<'p> WebhookWorker<'p> {
         if transactional {
             loop {
                 report_semaphore_utilization();
+                // TODO: We could grab semaphore permits here using something like:
+                //   `min(semaphore.available_permits(), dequeue_batch_size)`
+                // And then dequeue only up to that many jobs. We'd then need to hand back the
+                // difference in permits based on how many jobs were dequeued.
                 let mut batch = self.wait_for_jobs_tx().await;
                 dequeue_batch_size_histogram.record(batch.jobs.len() as f64);
 
@@ -227,6 +231,10 @@ impl<'p> WebhookWorker<'p> {
         } else {
             loop {
                 report_semaphore_utilization();
+                // TODO: We could grab semaphore permits here using something like:
+                //   `min(semaphore.available_permits(), dequeue_batch_size)`
+                // And then dequeue only up to that many jobs. We'd then need to hand back the
+                // difference in permits based on how many jobs were dequeued.
                 let batch = self.wait_for_jobs().await;
                 dequeue_batch_size_histogram.record(batch.jobs.len() as f64);
 

--- a/hook-worker/src/worker.rs
+++ b/hook-worker/src/worker.rs
@@ -2,7 +2,9 @@ use std::collections;
 use std::sync::Arc;
 use std::time;
 
+use futures::future::join_all;
 use hook_common::health::HealthHandle;
+use hook_common::pgqueue::{PgBatch, PgTransactionBatch};
 use hook_common::{
     pgqueue::{Job, PgJob, PgJobError, PgQueue, PgQueueError, PgQueueJob, PgTransactionJob},
     retry::RetryPolicy,
@@ -68,6 +70,8 @@ pub struct WebhookWorker<'p> {
     name: String,
     /// The queue we will be dequeuing jobs from.
     queue: &'p PgQueue,
+    /// The maximum number of jobs to dequeue in one query.
+    dequeue_count: u32,
     /// The interval for polling the queue.
     poll_interval: time::Duration,
     /// The client used for HTTP requests.
@@ -81,9 +85,11 @@ pub struct WebhookWorker<'p> {
 }
 
 impl<'p> WebhookWorker<'p> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: &str,
         queue: &'p PgQueue,
+        dequeue_count: u32,
         poll_interval: time::Duration,
         request_timeout: time::Duration,
         max_concurrent_jobs: usize,
@@ -106,6 +112,7 @@ impl<'p> WebhookWorker<'p> {
         Self {
             name: name.to_owned(),
             queue,
+            dequeue_count,
             poll_interval,
             client,
             max_concurrent_jobs,
@@ -114,16 +121,16 @@ impl<'p> WebhookWorker<'p> {
         }
     }
 
-    /// Wait until a job becomes available in our queue.
-    async fn wait_for_job<'a>(&self) -> PgJob<WebhookJobParameters, WebhookJobMetadata> {
+    /// Wait until at least one job becomes available in our queue.
+    async fn wait_for_jobs<'a>(&self) -> PgBatch<WebhookJobParameters, WebhookJobMetadata> {
         let mut interval = tokio::time::interval(self.poll_interval);
 
         loop {
             interval.tick().await;
             self.liveness.report_healthy().await;
 
-            match self.queue.dequeue(&self.name).await {
-                Ok(Some(job)) => return job,
+            match self.queue.dequeue(&self.name, self.dequeue_count).await {
+                Ok(Some(batch)) => return batch,
                 Ok(None) => continue,
                 Err(error) => {
                     error!("error while trying to dequeue job: {}", error);
@@ -133,18 +140,18 @@ impl<'p> WebhookWorker<'p> {
         }
     }
 
-    /// Wait until a job becomes available in our queue in transactional mode.
-    async fn wait_for_job_tx<'a>(
+    /// Wait until at least one job becomes available in our queue in transactional mode.
+    async fn wait_for_jobs_tx<'a>(
         &self,
-    ) -> PgTransactionJob<'a, WebhookJobParameters, WebhookJobMetadata> {
+    ) -> PgTransactionBatch<'a, WebhookJobParameters, WebhookJobMetadata> {
         let mut interval = tokio::time::interval(self.poll_interval);
 
         loop {
             interval.tick().await;
             self.liveness.report_healthy().await;
 
-            match self.queue.dequeue_tx(&self.name).await {
-                Ok(Some(job)) => return job,
+            match self.queue.dequeue_tx(&self.name, self.dequeue_count).await {
+                Ok(Some(batch)) => return batch,
                 Ok(None) => continue,
                 Err(error) => {
                     error!("error while trying to dequeue_tx job: {}", error);
@@ -165,65 +172,87 @@ impl<'p> WebhookWorker<'p> {
         if transactional {
             loop {
                 report_semaphore_utilization();
-                let webhook_job = self.wait_for_job_tx().await;
-                spawn_webhook_job_processing_task(
-                    self.client.clone(),
-                    semaphore.clone(),
-                    self.retry_policy.clone(),
-                    webhook_job,
-                )
-                .await;
+                let mut batch = self.wait_for_jobs_tx().await;
+
+                // Get enough permits for the jobs before spawning a task.
+                let permits = semaphore
+                    .clone()
+                    .acquire_many_owned(batch.jobs.len() as u32)
+                    .await
+                    .expect("semaphore has been closed");
+
+                let client = self.client.clone();
+                let retry_policy = self.retry_policy.clone();
+
+                tokio::spawn(async move {
+                    let mut futures = Vec::new();
+
+                    // We have to `take` the Vec of jobs from the batch to avoid a borrow checker
+                    // error below when we commit.
+                    for job in std::mem::take(&mut batch.jobs) {
+                        let client = client.clone();
+                        let retry_policy = retry_policy.clone();
+
+                        let future =
+                            async move { process_webhook_job(client, job, &retry_policy).await };
+
+                        futures.push(future);
+                    }
+
+                    let results = join_all(futures).await;
+                    for result in results {
+                        if let Err(e) = result {
+                            error!("error processing webhook job: {}", e);
+                        }
+                    }
+
+                    let _ = batch.commit().await.map_err(|e| {
+                        error!("error committing transactional batch: {}", e);
+                    });
+
+                    drop(permits);
+                });
             }
         } else {
             loop {
                 report_semaphore_utilization();
-                let webhook_job = self.wait_for_job().await;
-                spawn_webhook_job_processing_task(
-                    self.client.clone(),
-                    semaphore.clone(),
-                    self.retry_policy.clone(),
-                    webhook_job,
-                )
-                .await;
+                let batch = self.wait_for_jobs().await;
+
+                // Get enough permits for the jobs before spawning a task.
+                let permits = semaphore
+                    .clone()
+                    .acquire_many_owned(batch.jobs.len() as u32)
+                    .await
+                    .expect("semaphore has been closed");
+
+                let client = self.client.clone();
+                let retry_policy = self.retry_policy.clone();
+
+                tokio::spawn(async move {
+                    let mut futures = Vec::new();
+
+                    for job in batch.jobs {
+                        let client = client.clone();
+                        let retry_policy = retry_policy.clone();
+
+                        let future =
+                            async move { process_webhook_job(client, job, &retry_policy).await };
+
+                        futures.push(future);
+                    }
+
+                    let results = join_all(futures).await;
+                    for result in results {
+                        if let Err(e) = result {
+                            error!("error processing webhook job: {}", e);
+                        }
+                    }
+
+                    drop(permits);
+                });
             }
         }
     }
-}
-
-/// Spawn a Tokio task to process a Webhook Job once we successfully acquire a permit.
-///
-/// # Arguments
-///
-/// * `client`: An HTTP client to execute the webhook job request.
-/// * `semaphore`: A semaphore used for rate limiting purposes. This function will panic if this semaphore is closed.
-/// * `retry_policy`: The retry policy used to set retry parameters if a job fails and has remaining attempts.
-/// * `webhook_job`: The webhook job to process as dequeued from `hook_common::pgqueue::PgQueue`.
-async fn spawn_webhook_job_processing_task<W: WebhookJob + 'static>(
-    client: reqwest::Client,
-    semaphore: Arc<sync::Semaphore>,
-    retry_policy: RetryPolicy,
-    webhook_job: W,
-) -> tokio::task::JoinHandle<Result<(), WorkerError>> {
-    let permit = semaphore
-        .acquire_owned()
-        .await
-        .expect("semaphore has been closed");
-
-    let labels = [("queue", webhook_job.queue())];
-
-    metrics::counter!("webhook_jobs_total", &labels).increment(1);
-
-    tokio::spawn(async move {
-        let result = process_webhook_job(client, webhook_job, &retry_policy).await;
-        drop(permit);
-        match result {
-            Ok(_) => Ok(()),
-            Err(error) => {
-                error!("failed to process webhook job: {}", error);
-                Err(error)
-            }
-        }
-    })
 }
 
 /// Process a webhook job by transitioning it to its appropriate state after its request is sent.
@@ -248,6 +277,7 @@ async fn process_webhook_job<W: WebhookJob>(
     let parameters = webhook_job.parameters();
 
     let labels = [("queue", webhook_job.queue())];
+    metrics::counter!("webhook_jobs_total", &labels).increment(1);
 
     let now = tokio::time::Instant::now();
 
@@ -543,6 +573,7 @@ mod tests {
         let worker = WebhookWorker::new(
             &worker_id,
             &queue,
+            1,
             time::Duration::from_millis(100),
             time::Duration::from_millis(5000),
             10,
@@ -550,7 +581,7 @@ mod tests {
             liveness,
         );
 
-        let consumed_job = worker.wait_for_job().await;
+        let consumed_job = worker.wait_for_jobs().await.jobs.pop().unwrap();
 
         assert_eq!(consumed_job.job.attempt, 1);
         assert!(consumed_job.job.attempted_by.contains(&worker_id));


### PR DESCRIPTION
This amortizes the work done in both querying PG, and in the number of Tokio tasks spawned (we spawn 1 per *batch* rather than 1 per *job*).

The gist is that `PgJob` and `PgTransactionJob` are now wrapped in `PgBatch` and `PgTransactionBatch` respectively. Each contains a `Vec` of jobs. `dequeue` takes a `limit` parameter and returns up to that many jobs at once.

For non-txn jobs, everything is easy and mostly the same. I no longer hold a connection open for non-txn jobs (which is, to me, the benefit of non-txn jobs), so each job completes, then grabs a conn from the pool and does the query to finalize its work.

For txn jobs, we need to share the single txn object among them, and with the batch itself. Each one completes and grabs the txn via a mutex to do its work. After all work is done, the top-level Worker code is what calls commit.

In the future both of these could be optimized: the Worker code could do all Webhook stuff in parallel, and then updating the DB could be done in a batch query (or queries) rather than 1 per job. I'd rather do that as part of a future PR.
