### PR TITLE
declare a PG application name visible in PG stats

### DIFF
--- a/hook-api/src/config.rs
+++ b/hook-api/src/config.rs
@@ -13,6 +13,9 @@ pub struct Config {
 
     #[envconfig(default = "default")]
     pub queue_name: String,
+
+    #[envconfig(default = "100")]
+    pub max_pg_connections: u32,
 }
 
 impl Config {

--- a/hook-api/src/main.rs
+++ b/hook-api/src/main.rs
@@ -28,6 +28,7 @@ async fn main() {
         // side, but we don't need more than one queue for now.
         &config.queue_name,
         &config.database_url,
+        config.max_pg_connections,
         "hook-api",
     )
     .await

--- a/hook-api/src/main.rs
+++ b/hook-api/src/main.rs
@@ -28,6 +28,7 @@ async fn main() {
         // side, but we don't need more than one queue for now.
         &config.queue_name,
         &config.database_url,
+        "hook-api",
     )
     .await
     .expect("failed to initialize queue");

--- a/hook-common/src/pgqueue.rs
+++ b/hook-common/src/pgqueue.rs
@@ -524,12 +524,19 @@ impl PgQueue {
     ///
     /// * `queue_name`: A name for the queue we are going to initialize.
     /// * `url`: A URL pointing to where the PostgreSQL database is hosted.
-    pub async fn new(queue_name: &str, url: &str, app_name: &'static str) -> PgQueueResult<Self> {
+    pub async fn new(
+        queue_name: &str,
+        url: &str,
+        max_connections: u32,
+        app_name: &'static str,
+    ) -> PgQueueResult<Self> {
         let name = queue_name.to_owned();
         let options = PgConnectOptions::from_str(url)
             .map_err(|error| PgQueueError::PoolCreationError { error })?
             .application_name(app_name);
-        let pool = PgPoolOptions::new().connect_lazy_with(options);
+        let pool = PgPoolOptions::new()
+            .max_connections(max_connections)
+            .connect_lazy_with(options);
 
         Ok(Self { name, pool })
     }

--- a/hook-common/src/pgqueue.rs
+++ b/hook-common/src/pgqueue.rs
@@ -7,7 +7,7 @@ use std::time;
 use async_trait::async_trait;
 use chrono;
 use serde;
-use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
 use thiserror::Error;
 
 /// Enumeration of errors for operations with PgQueue.
@@ -524,11 +524,12 @@ impl PgQueue {
     ///
     /// * `queue_name`: A name for the queue we are going to initialize.
     /// * `url`: A URL pointing to where the PostgreSQL database is hosted.
-    pub async fn new(queue_name: &str, url: &str) -> PgQueueResult<Self> {
+    pub async fn new(queue_name: &str, url: &str, app_name: &'static str) -> PgQueueResult<Self> {
         let name = queue_name.to_owned();
-        let pool = PgPoolOptions::new()
-            .connect_lazy(url)
-            .map_err(|error| PgQueueError::PoolCreationError { error })?;
+        let options = PgConnectOptions::from_str(url)
+            .map_err(|error| PgQueueError::PoolCreationError { error })?
+            .application_name(app_name);
+        let pool = PgPoolOptions::new().connect_lazy_with(options);
 
         Ok(Self { name, pool })
     }

--- a/hook-worker/src/config.rs
+++ b/hook-worker/src/config.rs
@@ -29,6 +29,9 @@ pub struct Config {
     #[envconfig(default = "1024")]
     pub max_concurrent_jobs: usize,
 
+    #[envconfig(default = "100")]
+    pub max_pg_connections: u32,
+
     #[envconfig(nested = true)]
     pub retry_policy: RetryPolicyConfig,
 

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -38,6 +38,7 @@ async fn main() -> Result<(), WorkerError> {
     let queue = PgQueue::new(
         config.queue_name.as_str(),
         &config.database_url,
+        config.max_pg_connections,
         "hook-worker",
     )
     .await

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -35,9 +35,13 @@ async fn main() -> Result<(), WorkerError> {
         retry_policy_builder
     };
 
-    let queue = PgQueue::new(config.queue_name.as_str(), &config.database_url)
-        .await
-        .expect("failed to initialize queue");
+    let queue = PgQueue::new(
+        config.queue_name.as_str(),
+        &config.database_url,
+        "hook-worker",
+    )
+    .await
+    .expect("failed to initialize queue");
 
     let worker = WebhookWorker::new(
         &config.worker_name,


### PR DESCRIPTION
Declare an application name when connecting to PG. This name is shown in the PG query stats and can be helpful to debug locks.