### PR TITLE
configurable max_connections for api/worker, default to 100

### DIFF
--- a/hook-api/src/config.rs
+++ b/hook-api/src/config.rs
@@ -13,6 +13,9 @@ pub struct Config {
 
     #[envconfig(default = "default")]
     pub queue_name: String,
+
+    #[envconfig(default = "100")]
+    pub max_pg_connections: u32,
 }
 
 impl Config {

--- a/hook-api/src/main.rs
+++ b/hook-api/src/main.rs
@@ -28,6 +28,7 @@ async fn main() {
         // side, but we don't need more than one queue for now.
         &config.queue_name,
         &config.database_url,
+        config.max_pg_connections,
         "hook-api",
     )
     .await

--- a/hook-common/src/pgqueue.rs
+++ b/hook-common/src/pgqueue.rs
@@ -524,12 +524,19 @@ impl PgQueue {
     ///
     /// * `queue_name`: A name for the queue we are going to initialize.
     /// * `url`: A URL pointing to where the PostgreSQL database is hosted.
-    pub async fn new(queue_name: &str, url: &str, app_name: &'static str) -> PgQueueResult<Self> {
+    pub async fn new(
+        queue_name: &str,
+        url: &str,
+        max_connections: u32,
+        app_name: &'static str,
+    ) -> PgQueueResult<Self> {
         let name = queue_name.to_owned();
         let options = PgConnectOptions::from_str(url)
             .map_err(|error| PgQueueError::PoolCreationError { error })?
             .application_name(app_name);
-        let pool = PgPoolOptions::new().connect_lazy_with(options);
+        let pool = PgPoolOptions::new()
+            .max_connections(max_connections)
+            .connect_lazy_with(options);
 
         Ok(Self { name, pool })
     }

--- a/hook-worker/src/config.rs
+++ b/hook-worker/src/config.rs
@@ -29,6 +29,9 @@ pub struct Config {
     #[envconfig(default = "1024")]
     pub max_concurrent_jobs: usize,
 
+    #[envconfig(default = "100")]
+    pub max_pg_connections: u32,
+
     #[envconfig(nested = true)]
     pub retry_policy: RetryPolicyConfig,
 

--- a/hook-worker/src/main.rs
+++ b/hook-worker/src/main.rs
@@ -38,6 +38,7 @@ async fn main() -> Result<(), WorkerError> {
     let queue = PgQueue::new(
         config.queue_name.as_str(),
         &config.database_url,
+        config.max_pg_connections,
         "hook-worker",
     )
     .await


### PR DESCRIPTION
Janitor can keep the default (it only uses 1 at a time).