### PR TITLE
Add histogram for insertion time to completion time

### DIFF
--- a/hook-worker/src/worker.rs
+++ b/hook-worker/src/worker.rs
@@ -2,6 +2,7 @@ use std::collections;
 use std::sync::Arc;
 use std::time;
 
+use chrono::Utc;
 use hook_common::health::HealthHandle;
 use hook_common::{
     pgqueue::{Job, PgJob, PgJobError, PgQueue, PgQueueError, PgQueueJob, PgTransactionJob},
@@ -264,6 +265,10 @@ async fn process_webhook_job<W: WebhookJob>(
 
     match send_result {
         Ok(_) => {
+            let insert_to_complete_duration = Utc::now() - webhook_job.job().created_at;
+            metrics::histogram!("webhook_jobs_insert_to_complete_duration_seconds", &labels)
+                .record((insert_to_complete_duration.num_milliseconds() as f64) / 1_000_f64);
+
             webhook_job
                 .complete()
                 .await


### PR DESCRIPTION
~~Doh, `plugin-server` is deployed and sends the `created_at` field, but I forgot to consider that `hooks-api` wouldn't be serializing it into the DB until deployed, and so the race of deploying `hooks-api` and `hooks-worker` left rows that couldn't be deserialized in the DB.~~

~~Making this an `Option` as this field isn't critical to normal operation. I go ahead and set it in `hooks-api` if it's missing.~~

~~@xvello was right :)~~

Based on `created_at` column now.