### PR TITLE
fix: Panic on exceeding max retries

### DIFF
--- a/hook-api/src/handlers/app.rs
+++ b/hook-api/src/handlers/app.rs
@@ -30,9 +30,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn index(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", db)
-            .await
-            .expect("failed to construct pg_queue");
+        let pg_queue = PgQueue::new_from_pool("test_index", db).await;
 
         let app = add_routes(Router::new(), pg_queue);
 

--- a/hook-api/src/handlers/webhook.rs
+++ b/hook-api/src/handlers/webhook.rs
@@ -127,9 +127,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_success(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", db)
-            .await
-            .expect("failed to construct pg_queue");
+        let pg_queue = PgQueue::new_from_pool("test_index", db).await;
 
         let app = add_routes(Router::new(), pg_queue);
 
@@ -171,9 +169,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_bad_url(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", db)
-            .await
-            .expect("failed to construct pg_queue");
+        let pg_queue = PgQueue::new_from_pool("test_index", db).await;
 
         let app = add_routes(Router::new(), pg_queue);
 
@@ -210,9 +206,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_payload_missing_fields(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", db)
-            .await
-            .expect("failed to construct pg_queue");
+        let pg_queue = PgQueue::new_from_pool("test_index", db).await;
 
         let app = add_routes(Router::new(), pg_queue);
 
@@ -233,9 +227,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_payload_not_json(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", db)
-            .await
-            .expect("failed to construct pg_queue");
+        let pg_queue = PgQueue::new_from_pool("test_index", db).await;
 
         let app = add_routes(Router::new(), pg_queue);
 
@@ -256,9 +248,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_payload_body_too_large(db: PgPool) {
-        let pg_queue = PgQueue::new_from_pool("test_index", db)
-            .await
-            .expect("failed to construct pg_queue");
+        let pg_queue = PgQueue::new_from_pool("test_index", db).await;
 
         let app = add_routes(Router::new(), pg_queue);
 

--- a/hook-common/src/webhook.rs
+++ b/hook-common/src/webhook.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use serde::{de::Visitor, Deserialize, Serialize};
 
 use crate::kafka_messages::app_metrics;
-use crate::pgqueue::PgQueueError;
+use crate::pgqueue::ParseError;
 
 /// Supported HTTP methods for webhooks.
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -20,7 +20,7 @@ pub enum HttpMethod {
 
 /// Allow casting `HttpMethod` from strings.
 impl FromStr for HttpMethod {
-    type Err = PgQueueError;
+    type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_ascii_uppercase().as_ref() {
@@ -29,7 +29,7 @@ impl FromStr for HttpMethod {
             "PATCH" => Ok(HttpMethod::PATCH),
             "POST" => Ok(HttpMethod::POST),
             "PUT" => Ok(HttpMethod::PUT),
-            invalid => Err(PgQueueError::ParseHttpMethodError(invalid.to_owned())),
+            invalid => Err(ParseError::ParseHttpMethodError(invalid.to_owned())),
         }
     }
 }

--- a/hook-janitor/src/webhooks.rs
+++ b/hook-janitor/src/webhooks.rs
@@ -836,9 +836,7 @@ mod tests {
             WebhookCleaner::new_from_pool(db.clone(), mock_producer, APP_METRICS_TOPIC.to_owned())
                 .expect("unable to create webhook cleaner");
 
-        let queue = PgQueue::new_from_pool("webhooks", db.clone())
-            .await
-            .expect("failed to connect to local test postgresql database");
+        let queue = PgQueue::new_from_pool("webhooks", db.clone()).await;
 
         async fn get_count_from_new_conn(db: &PgPool, status: &str) -> i64 {
             let mut conn = db.acquire().await.unwrap();

--- a/hook-worker/src/error.rs
+++ b/hook-worker/src/error.rs
@@ -24,10 +24,10 @@ pub enum WebhookError {
 /// Enumeration of errors related to initialization and consumption of webhook jobs.
 #[derive(Error, Debug)]
 pub enum WorkerError {
+    #[error("a database error occurred when executing a job")]
+    DatabaseError(#[from] pgqueue::DatabaseError),
+    #[error("a parsing error occurred in the underlying queue")]
+    QueueParseError(#[from] pgqueue::ParseError),
     #[error("timed out while waiting for jobs to be available")]
     TimeoutError,
-    #[error("an error occurred in the underlying queue")]
-    QueueError(#[from] pgqueue::PgQueueError),
-    #[error("an error occurred in the underlying job: {0}")]
-    PgJobError(String),
 }

--- a/hook-worker/src/worker.rs
+++ b/hook-worker/src/worker.rs
@@ -279,7 +279,10 @@ async fn process_webhook_job<W: WebhookJob>(
             webhook_job
                 .fail(WebhookJobError::new_parse(&e.to_string()))
                 .await
-                .map_err(|job_error| WorkerError::PgJobError(job_error.to_string()))?;
+                .map_err(|job_error| {
+                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    WorkerError::PgJobError(job_error.to_string())
+                })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
 
@@ -289,7 +292,10 @@ async fn process_webhook_job<W: WebhookJob>(
             webhook_job
                 .fail(WebhookJobError::new_parse(&e))
                 .await
-                .map_err(|job_error| WorkerError::PgJobError(job_error.to_string()))?;
+                .map_err(|job_error| {
+                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    WorkerError::PgJobError(job_error.to_string())
+                })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
 
@@ -299,7 +305,10 @@ async fn process_webhook_job<W: WebhookJob>(
             webhook_job
                 .fail(WebhookJobError::new_parse(&e.to_string()))
                 .await
-                .map_err(|job_error| WorkerError::PgJobError(job_error.to_string()))?;
+                .map_err(|job_error| {
+                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    WorkerError::PgJobError(job_error.to_string())
+                })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
 
@@ -326,7 +335,10 @@ async fn process_webhook_job<W: WebhookJob>(
                     webhook_job
                         .fail(WebhookJobError::from(&error))
                         .await
-                        .map_err(|job_error| WorkerError::PgJobError(job_error.to_string()))?;
+                        .map_err(|job_error| {
+                            metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                            WorkerError::PgJobError(job_error.to_string())
+                        })?;
 
                     metrics::counter!("webhook_jobs_failed", &labels).increment(1);
 
@@ -339,7 +351,10 @@ async fn process_webhook_job<W: WebhookJob>(
             webhook_job
                 .fail(WebhookJobError::from(&error))
                 .await
-                .map_err(|job_error| WorkerError::PgJobError(job_error.to_string()))?;
+                .map_err(|job_error| {
+                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    WorkerError::PgJobError(job_error.to_string())
+                })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
 

--- a/hook-worker/src/worker.rs
+++ b/hook-worker/src/worker.rs
@@ -280,7 +280,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .fail(WebhookJobError::new_parse(&e.to_string()))
                 .await
                 .map_err(|job_error| {
-                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
                     WorkerError::PgJobError(job_error.to_string())
                 })?;
 
@@ -293,7 +293,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .fail(WebhookJobError::new_parse(&e))
                 .await
                 .map_err(|job_error| {
-                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
                     WorkerError::PgJobError(job_error.to_string())
                 })?;
 
@@ -306,7 +306,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .fail(WebhookJobError::new_parse(&e.to_string()))
                 .await
                 .map_err(|job_error| {
-                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
                     WorkerError::PgJobError(job_error.to_string())
                 })?;
 
@@ -336,7 +336,7 @@ async fn process_webhook_job<W: WebhookJob>(
                         .fail(WebhookJobError::from(&error))
                         .await
                         .map_err(|job_error| {
-                            metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                            metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
                             WorkerError::PgJobError(job_error.to_string())
                         })?;
 
@@ -344,7 +344,11 @@ async fn process_webhook_job<W: WebhookJob>(
 
                     Ok(())
                 }
-                Err(job_error) => Err(WorkerError::PgJobError(job_error.to_string())),
+                Err(job_error) => {
+                    metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
+
+                    Err(WorkerError::PgJobError(job_error.to_string()))
+                }
             }
         }
         Err(WebhookError::NonRetryableRetryableRequestError(error)) => {
@@ -352,7 +356,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .fail(WebhookJobError::from(&error))
                 .await
                 .map_err(|job_error| {
-                    metrics::counter!("webhook_jobs_failed", &labels).increment(1);
+                    metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
                     WorkerError::PgJobError(job_error.to_string())
                 })?;
 

--- a/hook-worker/src/worker.rs
+++ b/hook-worker/src/worker.rs
@@ -4,7 +4,10 @@ use std::time;
 
 use hook_common::health::HealthHandle;
 use hook_common::{
-    pgqueue::{Job, PgJob, PgJobError, PgQueue, PgQueueError, PgQueueJob, PgTransactionJob},
+    pgqueue::{
+        DatabaseError, Job, PgJob, PgQueue, PgQueueJob, PgTransactionJob, RetryError,
+        RetryInvalidError,
+    },
     retry::RetryPolicy,
     webhook::{HttpMethod, WebhookJobError, WebhookJobMetadata, WebhookJobParameters},
 };
@@ -264,10 +267,10 @@ async fn process_webhook_job<W: WebhookJob>(
 
     match send_result {
         Ok(_) => {
-            webhook_job
-                .complete()
-                .await
-                .map_err(|error| WorkerError::PgJobError(error.to_string()))?;
+            webhook_job.complete().await.map_err(|error| {
+                metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
+                error
+            })?;
 
             metrics::counter!("webhook_jobs_completed", &labels).increment(1);
             metrics::histogram!("webhook_jobs_processing_duration_seconds", &labels)
@@ -281,7 +284,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .await
                 .map_err(|job_error| {
                     metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
-                    WorkerError::PgJobError(job_error.to_string())
+                    job_error
                 })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
@@ -294,7 +297,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .await
                 .map_err(|job_error| {
                     metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
-                    WorkerError::PgJobError(job_error.to_string())
+                    job_error
                 })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
@@ -307,7 +310,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .await
                 .map_err(|job_error| {
                     metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
-                    WorkerError::PgJobError(job_error.to_string())
+                    job_error
                 })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
@@ -329,25 +332,24 @@ async fn process_webhook_job<W: WebhookJob>(
 
                     Ok(())
                 }
-                Err(PgJobError::RetryInvalidError {
+                Err(RetryError::RetryInvalidError(RetryInvalidError {
                     job: webhook_job, ..
-                }) => {
+                })) => {
                     webhook_job
                         .fail(WebhookJobError::from(&error))
                         .await
                         .map_err(|job_error| {
                             metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
-                            WorkerError::PgJobError(job_error.to_string())
+                            job_error
                         })?;
 
                     metrics::counter!("webhook_jobs_failed", &labels).increment(1);
 
                     Ok(())
                 }
-                Err(job_error) => {
+                Err(RetryError::DatabaseError(job_error)) => {
                     metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
-
-                    Err(WorkerError::PgJobError(job_error.to_string()))
+                    Err(WorkerError::from(job_error))
                 }
             }
         }
@@ -357,7 +359,7 @@ async fn process_webhook_job<W: WebhookJob>(
                 .await
                 .map_err(|job_error| {
                     metrics::counter!("webhook_jobs_database_error", &labels).increment(1);
-                    WorkerError::PgJobError(job_error.to_string())
+                    job_error
                 })?;
 
             metrics::counter!("webhook_jobs_failed", &labels).increment(1);
@@ -487,7 +489,7 @@ mod tests {
         max_attempts: i32,
         job_parameters: WebhookJobParameters,
         job_metadata: WebhookJobMetadata,
-    ) -> Result<(), PgQueueError> {
+    ) -> Result<(), DatabaseError> {
         let job_target = job_parameters.url.to_owned();
         let new_job = NewJob::new(max_attempts, job_metadata, job_parameters, &job_target);
         queue.enqueue(new_job).await?;
@@ -528,9 +530,7 @@ mod tests {
     async fn test_wait_for_job(db: PgPool) {
         let worker_id = worker_id();
         let queue_name = "test_wait_for_job".to_string();
-        let queue = PgQueue::new_from_pool(&queue_name, db)
-            .await
-            .expect("failed to connect to PG");
+        let queue = PgQueue::new_from_pool(&queue_name, db).await;
 
         let webhook_job_parameters = WebhookJobParameters {
             body: "a webhook job body. much wow.".to_owned(),


### PR DESCRIPTION
As it stands, the only thing stopping us from retrying jobs indefinitely is an `if` check in the `retry` method. However, future refactors may omit this check for one reason or another. 

Ideally, the transition to a `RetryableJob` should fail and give the caller the chance to recover by failing the job instead. The reason we don't do this is that we return the wrapper `PgJob`/`PgTransactionJob` in the event a `retry` is not possible so that it may be failed by the worker instead. However, we require ownership of the underlying `job` when transitioning to a `RetryableJob`, so if we were to return the wrapper `PgJob` or `PgTransactionJob` when the transition fails it would be too late as partial ownership has already been moved to `retryable`. So, we do not error on the transition but instead enforce it with an if check.

To make things safer, I've added a panic in the transition. This way, we'll crash upon forgetting to check if the job can be retried. While we experiment on how to change this, at least the panic will prevent potential data corruption (for example, a job is updated with attempts beyond its max attempts).

Naturally, I'm not super thrilled about this approach: Although safer, I would like to give callers the chance to recover (by failing the job instead of recovering) which we are not doing with a panic. 

An idea I'm consedering is including retrying as part of `fail` (perhaps renaming the method to something like `retry_or_fail`). This way, we don't have to return the `PgJob`/`PgTransactionJob` as the recovery from a failed retry (failing the job) will be executed immediately after without requiring the caller to do it and thus requiring ownership to be moved back to the caller. The caller can check if the return type is a `RetriedJob` or a `FailedJob` to deduce what transition happened.

Any thoughts?